### PR TITLE
test: silence console output in tests

### DIFF
--- a/__tests__/console.silence.test.js
+++ b/__tests__/console.silence.test.js
@@ -1,0 +1,10 @@
+import { jest } from '@jest/globals';
+
+describe('console output', () => {
+  test('console.log does not write to stdout', () => {
+    const spy = jest.spyOn(process.stdout, 'write');
+    console.log('hidden');
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,8 @@
+/**
+ * Jest setup file to silence console output during tests.
+ */
+function noop() {}
+console.log = noop;
+console.info = noop;
+console.warn = noop;
+console.error = noop;

--- a/live-reload.json
+++ b/live-reload.json
@@ -1,1 +1,1 @@
-{"version":"ffd096da","time":1757323058183}
+{"version":"ffd096da","time":1757323483838}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:serve": "http-server . -p 8000 -c-1",
     "dev:watch": "node tools/dev-watch.mjs",
     "dev": "npm run dev:watch & npm run dev:serve",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --setupFilesAfterEnv=./jest.setup.js",
     "test:coverage": "npm run test -- --coverage",
     "simulate": "node tools/simulate.mjs",
     "ingest": "node tools/cards-ingest.mjs",


### PR DESCRIPTION
## Summary
- stub console methods via Jest setup to prevent logs during tests
- load setup file in npm test script
- verify console.log is silent in new test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bea0449ab88323ab66690435c7279c