### PR TITLE
feat: move dead allies to graveyard

### DIFF
--- a/__tests__/systems.effects.test.js
+++ b/__tests__/systems.effects.test.js
@@ -1,0 +1,20 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+describe('EffectSystem', () => {
+  test('dead allies move from battlefield to graveyard', () => {
+    const game = new Game();
+    const player = game.player;
+    const ally = new Card({ type: 'ally', name: 'A', data: { attack: 0, health: 1 } });
+    player.battlefield.add(ally);
+
+    game.effects.dealDamage(
+      { target: 'allCharacters', amount: 1 },
+      { game, player, card: null }
+    );
+
+    expect(player.battlefield.cards.length).toBe(0);
+    expect(player.graveyard.cards).toContain(ally);
+  });
+});
+

--- a/live-reload.json
+++ b/live-reload.json
@@ -1,1 +1,1 @@
-{"version":"ffd096da","time":1757323483838}
+{"version":"ffd096da","time":1757323759676}

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -99,11 +99,15 @@ export class EffectSystem {
       if (t.data && t.data.health != null) {
         t.data.health -= amount;
         console.log(`${t.name} took ${amount} damage. Remaining health: ${t.data.health}`);
+        if (t.data.health <= 0) t.data.dead = true;
       } else if (t.health != null) { // For hero
         t.health -= amount;
         console.log(`${t.name} took ${amount} damage. Remaining health: ${t.health}`);
       }
     }
+
+    game.cleanupDeaths(player);
+    game.cleanupDeaths(game.opponent);
   }
 
   summonUnit(effect, context) {


### PR DESCRIPTION
## Summary
- Mark damage-killed allies as dead and clean them up immediately
- Add test to confirm dead allies move from battlefield to graveyard

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bea172dfd8832395e17fe347e0ff47