### PR TITLE
test: cover card effects and fix RNG

### DIFF
--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -1,0 +1,135 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+
+const cards = JSON.parse(fs.readFileSync(new URL('../data/cards.json', import.meta.url)));
+const effectCards = cards.filter(c => c.effects && c.effects[0] && c.effects[0].type !== 'rawText');
+
+describe.each(effectCards)('$id executes its effect', (card) => {
+  test('effect works as defined', async () => {
+    const g = new Game();
+    await g.setupMatch();
+
+    // clean zones for deterministic counts
+    g.player.hand.cards = [];
+    g.opponent.hand.cards = [];
+    g.player.battlefield.cards = [];
+    g.opponent.battlefield.cards = [];
+
+    // plenty of resources
+    g.resources._pool.set(g.player, 10);
+    g.resources._pool.set(g.opponent, 10);
+
+    const effect = card.effects[0];
+
+    if (card.type === 'hero') {
+      g.player.hero = new Hero(card);
+      if (effect.type === 'heal') {
+        g.player.hero.data.maxHealth = 30;
+        g.player.hero.data.health = 20;
+        g.effects.execute(card.effects, { game: g, player: g.player, card: g.player.hero });
+        expect(g.player.hero.data.health).toBe(20 + effect.amount);
+      } else if (effect.type === 'damage') {
+        const before = g.opponent.hero.data.health;
+        g.effects.execute(card.effects, { game: g, player: g.player, card: g.player.hero });
+        expect(g.opponent.hero.data.health).toBe(before - effect.amount);
+      } else if (effect.type === 'draw') {
+        const handBefore = g.player.hand.cards.length;
+        g.effects.execute(card.effects, { game: g, player: g.player, card: g.player.hero });
+        expect(g.player.hand.cards.length).toBe(handBefore + effect.count);
+      }
+      return;
+    }
+
+    g.addCardToHand(card.id);
+    const handStart = g.player.hand.cards.length;
+
+    switch (effect.type) {
+      case 'damage': {
+        if (effect.target === 'allCharacters') {
+          g.player.battlefield.add(new Card({ name: 'Ally', type: 'ally', data: { attack: 0, health: 5 }, keywords: [] }));
+          g.opponent.battlefield.add(new Card({ name: 'Enemy', type: 'ally', data: { attack: 0, health: 5 }, keywords: [] }));
+        }
+        if (effect.target === 'allEnemies') {
+          g.opponent.battlefield.add(new Card({ name: 'Enemy', type: 'ally', data: { attack: 0, health: 5 }, keywords: [] }));
+        }
+        const oppBefore = g.opponent.hero.data.health;
+        const playerBefore = g.player.hero.data.health;
+        g.playFromHand(g.player, card.id);
+        expect(g.opponent.hero.data.health).toBe(oppBefore - effect.amount);
+        if (effect.target === 'allCharacters') {
+          expect(g.player.hero.data.health).toBe(playerBefore - effect.amount);
+        }
+        break;
+      }
+      case 'summon': {
+        const bfBefore = g.player.battlefield.cards.length;
+        g.playFromHand(g.player, card.id);
+        const expected = bfBefore + effect.count + (card.type === 'ally' ? 1 : 0);
+        expect(g.player.battlefield.cards.length).toBe(expected);
+        const summoned = g.player.battlefield.cards.filter(c => c.name === effect.unit.name);
+        expect(summoned.length).toBe(effect.count);
+        expect(summoned[0].data.attack).toBe(effect.unit.attack);
+        expect(summoned[0].data.health).toBe(effect.unit.health);
+        break;
+      }
+      case 'buff': {
+        g.player.battlefield.add(new Card({ name: 'Ally', type: 'ally', data: { attack: 1, health: 1 }, keywords: [] }));
+        const heroAttack = g.player.hero.data.attack || 0;
+        g.playFromHand(g.player, card.id);
+        expect(g.player.hero.data.attack).toBe(heroAttack + effect.amount);
+        break;
+      }
+      case 'overload': {
+        const overloadBefore = g.resources._overloadNext.get(g.player) || 0;
+        g.playFromHand(g.player, card.id);
+        expect(g.resources._overloadNext.get(g.player)).toBe(overloadBefore + effect.amount);
+        break;
+      }
+      case 'heal': {
+        g.player.hero.data.maxHealth = 30;
+        g.player.hero.data.health = 20;
+        g.playFromHand(g.player, card.id);
+        expect(g.player.hero.data.health).toBe(20 + effect.amount);
+        break;
+      }
+      case 'draw': {
+        g.playFromHand(g.player, card.id);
+        expect(g.player.hand.cards.length).toBe(handStart - 1 + effect.count);
+        break;
+      }
+      case 'destroy': {
+        g.opponent.battlefield.add(new Card({ name: 'Enemy', type: 'ally', data: { attack: 2, health: 2 }, keywords: [] }));
+        g.playFromHand(g.player, card.id);
+        expect(g.opponent.battlefield.cards.length).toBe(0);
+        break;
+      }
+      case 'returnToHand': {
+        const enemy = new Card({ name: 'Enemy', type: 'ally', cost: 2, data: { attack: 2, health: 2 }, keywords: [] });
+        g.opponent.battlefield.add(enemy);
+        g.playFromHand(g.player, card.id);
+        expect(g.opponent.battlefield.cards.length).toBe(0);
+        expect(g.opponent.hand.cards[0].cost).toBe(3);
+        break;
+      }
+      case 'transform': {
+        const ally = new Card({ name: 'Ally', type: 'ally', data: { attack: 1, health: 1 }, keywords: [] });
+        g.player.battlefield.add(ally);
+        g.playFromHand(g.player, card.id);
+        const transformed = g.player.battlefield.cards[0];
+        expect(transformed.name).toBe(effect.into.name);
+        expect(transformed.data.attack).toBe(effect.into.attack);
+        expect(transformed.data.health).toBe(effect.into.health);
+        expect(transformed.keywords).toEqual(effect.into.keywords);
+        break;
+      }
+      default:
+        throw new Error('Unhandled effect type: ' + effect.type);
+    }
+
+    if (card.id === 'spell-feral-spirit') {
+      expect(g.resources._overloadNext.get(g.player)).toBe(2);
+    }
+  });
+});

--- a/live-reload.json
+++ b/live-reload.json
@@ -1,1 +1,1 @@
-{"version":"ffd096da","time":1757323759676}
+{"version":"ffd096da","time":1757324635936}

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -23,6 +23,7 @@ export default class Game {
     this.resources = new ResourceSystem(this.turns);
     this.combat = new CombatSystem();
     this.effects = new EffectSystem(this);
+    this.rng = new RNG();
 
     // Players
     this.player = new Player({ name: 'You' });
@@ -61,7 +62,7 @@ export default class Game {
     const heroes = this.allCards.filter(c => c.type === 'hero');
     const otherCards = this.allCards.filter(c => c.type !== 'hero');
 
-    const rng = new RNG();
+    const rng = this.rng;
 
     // Assign heroes
     const playerHeroData = rng.pick(heroes);


### PR DESCRIPTION
## Summary
- initialize a shared RNG on the `Game` instance so random effect targets work
- add tests for every card with implemented effects, covering damage, summoning, buffs, and more

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bea46d616483239f78c5d651b57ca5