### PR TITLE
feat: add hero panes to play UI

### DIFF
--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -1,0 +1,32 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+import { renderPlay } from '../src/js/ui/play.js';
+import Hero from '../src/js/entities/hero.js';
+
+describe('UI Play', () => {
+  test('renders hero panes with name, health, and abilities', () => {
+    const container = document.createElement('div');
+    const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 }, text: 'Player ability', keywords: ['Swift'] });
+    const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 }, text: 'Enemy ability', keywords: ['Stealth'] });
+
+    const game = {
+      player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      resources: { pool: () => 0, available: () => 0 },
+      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+    };
+
+    renderPlay(container, game);
+
+    const playerPane = container.querySelector('.row.player .hero-pane');
+    expect(playerPane.textContent).toContain('Player Hero');
+    expect(playerPane.textContent).toContain('Health: 25');
+    expect(playerPane.textContent).toContain('Player ability');
+
+    const enemyPane = container.querySelector('.row.enemy .hero-pane');
+    expect(enemyPane.textContent).toContain('Enemy Hero');
+    expect(enemyPane.textContent).toContain('Health: 20');
+    expect(enemyPane.textContent).toContain('Enemy ability');
+  });
+});
+

--- a/live-reload.json
+++ b/live-reload.json
@@ -1,1 +1,1 @@
-{"version":"ffd096da","time":1757324635936}
+{"version":"ffd096da","time":1757325363623}

--- a/src/js/entities/hero.js
+++ b/src/js/entities/hero.js
@@ -1,11 +1,18 @@
 import { shortId } from '../utils/id.js';
 
 export default class Hero {
-  constructor({ id, name = 'Hero', attack = 0, health = 30, armor = 0 } = {}) {
+  constructor({ id, name = 'Hero', data = {}, attack = 0, health = 30, armor = 0, keywords = [], text = '', effects = [] } = {}) {
     this.id = id || shortId('hero');
     this.name = name;
+    if (data) {
+      attack = data.attack ?? attack;
+      health = data.health ?? health;
+      armor = data.armor ?? armor;
+    }
     this.data = { attack, health, armor };
-    this.keywords = [];
+    this.keywords = keywords;
+    this.effects = effects;
+    this.text = text;
     this.equipment = [];
   }
 

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -25,6 +25,20 @@ function zoneList(title, cards, { clickCard, game, showTooltip, hideTooltip } = 
   return el('section', {}, el('h3', {}, title), ul);
 }
 
+function heroPane(hero) {
+  const abilities = [];
+  if (hero.text) abilities.push(el('p', { class: 'ability-text' }, hero.text));
+  if (hero.keywords?.length) {
+    const ul = el('ul', { class: 'abilities' }, ...hero.keywords.map(k => el('li', {}, k)));
+    abilities.push(ul);
+  }
+  return el('div', { class: 'hero-pane' },
+    el('h3', {}, hero.name),
+    el('p', {}, `Health: ${hero.data.health}`),
+    ...abilities
+  );
+}
+
 export function renderPlay(container, game, { onUpdate } = {}) {
   const p = game.player; const e = game.opponent;
   container.innerHTML = '';
@@ -70,10 +84,12 @@ export function renderPlay(container, game, { onUpdate } = {}) {
   );
 
   const playerRow = el('div', { class: 'row player' },
+    heroPane(p.hero),
     el('div', { class: 'zone' }, zoneList('Player Battlefield', p.battlefield.cards, { clickCard: (c)=>{ game.toggleAttacker(p, c.id); onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
     el('div', { class: 'zone' }, zoneList('Player Hand', p.hand.cards, { clickCard: (c)=>{ if (!game.playFromHand(p, c.id)) { /* ignore */ } onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip }))
   );
   const enemyRow = el('div', { class: 'row enemy' },
+    heroPane(e.hero),
     el('div', { class: 'zone' }, zoneList('Enemy Battlefield', e.battlefield.cards, { game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
     el('div', { class: 'zone' }, el('h3', {}, 'Enemy Hand'), el('p', {}, `${e.hand.size()} cards`))
   );


### PR DESCRIPTION
## Summary
- show hero name, health, and abilities for both players during play
- load hero ability metadata in Hero entity
- cover hero pane rendering with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bea7be4a2c8323b800ba4359e856a7