### PR TITLE
feat: add target selection UI for card effects

### DIFF
--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -28,15 +28,15 @@ describe.each(effectCards)('$id executes its effect', (card) => {
       if (effect.type === 'heal') {
         g.player.hero.data.maxHealth = 30;
         g.player.hero.data.health = 20;
-        g.effects.execute(card.effects, { game: g, player: g.player, card: g.player.hero });
+        await g.effects.execute(card.effects, { game: g, player: g.player, card: g.player.hero });
         expect(g.player.hero.data.health).toBe(20 + effect.amount);
       } else if (effect.type === 'damage') {
         const before = g.opponent.hero.data.health;
-        g.effects.execute(card.effects, { game: g, player: g.player, card: g.player.hero });
+        await g.effects.execute(card.effects, { game: g, player: g.player, card: g.player.hero });
         expect(g.opponent.hero.data.health).toBe(before - effect.amount);
       } else if (effect.type === 'draw') {
         const handBefore = g.player.hand.cards.length;
-        g.effects.execute(card.effects, { game: g, player: g.player, card: g.player.hero });
+        await g.effects.execute(card.effects, { game: g, player: g.player, card: g.player.hero });
         expect(g.player.hand.cards.length).toBe(handBefore + effect.count);
       }
       return;
@@ -54,18 +54,27 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         if (effect.target === 'allEnemies') {
           g.opponent.battlefield.add(new Card({ name: 'Enemy', type: 'ally', data: { attack: 0, health: 5 }, keywords: [] }));
         }
-        const oppBefore = g.opponent.hero.data.health;
-        const playerBefore = g.player.hero.data.health;
-        g.playFromHand(g.player, card.id);
-        expect(g.opponent.hero.data.health).toBe(oppBefore - effect.amount);
-        if (effect.target === 'allCharacters') {
-          expect(g.player.hero.data.health).toBe(playerBefore - effect.amount);
+        if (['any', 'minion', 'enemyHeroOrMinionWithoutTaunt', 'character'].includes(effect.target)) {
+          const enemy = new Card({ name: 'Enemy', type: 'ally', data: { attack: 0, health: 5 }, keywords: [] });
+          g.opponent.battlefield.add(enemy);
+          g.promptTarget = async () => enemy;
+          const before = enemy.data.health;
+          await g.playFromHand(g.player, card.id);
+          expect(enemy.data.health).toBe(before - effect.amount);
+        } else {
+          const oppBefore = g.opponent.hero.data.health;
+          const playerBefore = g.player.hero.data.health;
+          await g.playFromHand(g.player, card.id);
+          expect(g.opponent.hero.data.health).toBe(oppBefore - effect.amount);
+          if (effect.target === 'allCharacters') {
+            expect(g.player.hero.data.health).toBe(playerBefore - effect.amount);
+          }
         }
         break;
       }
       case 'summon': {
         const bfBefore = g.player.battlefield.cards.length;
-        g.playFromHand(g.player, card.id);
+        await g.playFromHand(g.player, card.id);
         const expected = bfBefore + effect.count + (card.type === 'ally' ? 1 : 0);
         expect(g.player.battlefield.cards.length).toBe(expected);
         const summoned = g.player.battlefield.cards.filter(c => c.name === effect.unit.name);
@@ -77,38 +86,38 @@ describe.each(effectCards)('$id executes its effect', (card) => {
       case 'buff': {
         g.player.battlefield.add(new Card({ name: 'Ally', type: 'ally', data: { attack: 1, health: 1 }, keywords: [] }));
         const heroAttack = g.player.hero.data.attack || 0;
-        g.playFromHand(g.player, card.id);
+        await g.playFromHand(g.player, card.id);
         expect(g.player.hero.data.attack).toBe(heroAttack + effect.amount);
         break;
       }
       case 'overload': {
         const overloadBefore = g.resources._overloadNext.get(g.player) || 0;
-        g.playFromHand(g.player, card.id);
+        await g.playFromHand(g.player, card.id);
         expect(g.resources._overloadNext.get(g.player)).toBe(overloadBefore + effect.amount);
         break;
       }
       case 'heal': {
         g.player.hero.data.maxHealth = 30;
         g.player.hero.data.health = 20;
-        g.playFromHand(g.player, card.id);
+        await g.playFromHand(g.player, card.id);
         expect(g.player.hero.data.health).toBe(20 + effect.amount);
         break;
       }
       case 'draw': {
-        g.playFromHand(g.player, card.id);
+        await g.playFromHand(g.player, card.id);
         expect(g.player.hand.cards.length).toBe(handStart - 1 + effect.count);
         break;
       }
       case 'destroy': {
         g.opponent.battlefield.add(new Card({ name: 'Enemy', type: 'ally', data: { attack: 2, health: 2 }, keywords: [] }));
-        g.playFromHand(g.player, card.id);
+        await g.playFromHand(g.player, card.id);
         expect(g.opponent.battlefield.cards.length).toBe(0);
         break;
       }
       case 'returnToHand': {
         const enemy = new Card({ name: 'Enemy', type: 'ally', cost: 2, data: { attack: 2, health: 2 }, keywords: [] });
         g.opponent.battlefield.add(enemy);
-        g.playFromHand(g.player, card.id);
+        await g.playFromHand(g.player, card.id);
         expect(g.opponent.battlefield.cards.length).toBe(0);
         expect(g.opponent.hand.cards[0].cost).toBe(3);
         break;
@@ -116,7 +125,7 @@ describe.each(effectCards)('$id executes its effect', (card) => {
       case 'transform': {
         const ally = new Card({ name: 'Ally', type: 'ally', data: { attack: 1, health: 1 }, keywords: [] });
         g.player.battlefield.add(ally);
-        g.playFromHand(g.player, card.id);
+        await g.playFromHand(g.player, card.id);
         const transformed = g.player.battlefield.cards[0];
         expect(transformed.name).toBe(effect.into.name);
         expect(transformed.data.attack).toBe(effect.into.attack);

--- a/__tests__/game.playFromHand.test.js
+++ b/__tests__/game.playFromHand.test.js
@@ -1,11 +1,11 @@
 import Game from '../src/js/game.js';
 import Card from '../src/js/entities/card.js';
 
-test('playing an ally moves it from hand to battlefield', () => {
+test('playing an ally moves it from hand to battlefield', async () => {
   const g = new Game();
   const ally = new Card({ type: 'ally', name: 'Footman', cost: 0 });
   g.player.hand.add(ally);
-  const result = g.playFromHand(g.player, ally.id);
+  const result = await g.playFromHand(g.player, ally.id);
   expect(result).toBe(true);
   expect(g.player.battlefield.cards).toContain(ally);
   expect(g.player.hand.cards).not.toContain(ally);

--- a/__tests__/systems.effects.test.js
+++ b/__tests__/systems.effects.test.js
@@ -1,20 +1,39 @@
+import { jest } from '@jest/globals';
 import Game from '../src/js/game.js';
 import Card from '../src/js/entities/card.js';
 
 describe('EffectSystem', () => {
-  test('dead allies move from battlefield to graveyard', () => {
+  test('dead allies move from battlefield to graveyard', async () => {
     const game = new Game();
     const player = game.player;
     const ally = new Card({ type: 'ally', name: 'A', data: { attack: 0, health: 1 } });
     player.battlefield.add(ally);
 
-    game.effects.dealDamage(
+    await game.effects.dealDamage(
       { target: 'allCharacters', amount: 1 },
       { game, player, card: null }
     );
 
     expect(player.battlefield.cards.length).toBe(0);
     expect(player.graveyard.cards).toContain(ally);
+  });
+
+  test('dealDamage prompts for target and applies damage', async () => {
+    const game = new Game();
+    const player = game.player;
+    const enemy = new Card({ type: 'ally', name: 'E', data: { attack: 0, health: 3 } });
+    game.opponent.battlefield.add(enemy);
+
+    const promptSpy = jest.fn(async () => enemy);
+    game.promptTarget = promptSpy;
+
+    await game.effects.dealDamage(
+      { target: 'any', amount: 2 },
+      { game, player, card: null }
+    );
+
+    expect(promptSpy).toHaveBeenCalled();
+    expect(enemy.data.health).toBe(1);
   });
 });
 

--- a/live-reload.json
+++ b/live-reload.json
@@ -1,1 +1,1 @@
-{"version":"ffd096da","time":1757325363623}
+{"version":"ffd096da","time":1757325895877}

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -14,7 +14,7 @@ function zoneList(title, cards, { clickCard, game, showTooltip, hideTooltip } = 
   for (const c of cards) {
     const cost = c.cost != null ? ` (${c.cost})` : '';
     const li = el('li', { dataset: { cardId: c.id } }, `${c.name}${cost}`);
-    if (clickCard) li.addEventListener('click', () => clickCard(c));
+    if (clickCard) li.addEventListener('click', async () => { await clickCard(c); });
 
     // Add mouseover and mouseout listeners
     li.addEventListener('mouseover', (e) => showTooltip(c, e, game));
@@ -80,13 +80,13 @@ export function renderPlay(container, game, { onUpdate } = {}) {
     el('button', { onclick: () => { game.draw(p, 1); onUpdate?.(); } }, 'Draw'),
     el('button', { onclick: () => { onUpdate?.(); } }, 'Refresh'),
     el('button', { onclick: () => { game.resolveCombat(p, e); onUpdate?.(); } }, 'Resolve Combat'),
-    el('button', { onclick: () => { game.endTurn(); onUpdate?.(); } }, 'End Turn')
+    el('button', { onclick: async () => { await game.endTurn(); onUpdate?.(); } }, 'End Turn')
   );
 
   const playerRow = el('div', { class: 'row player' },
     heroPane(p.hero),
     el('div', { class: 'zone' }, zoneList('Player Battlefield', p.battlefield.cards, { clickCard: (c)=>{ game.toggleAttacker(p, c.id); onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
-    el('div', { class: 'zone' }, zoneList('Player Hand', p.hand.cards, { clickCard: (c)=>{ if (!game.playFromHand(p, c.id)) { /* ignore */ } onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip }))
+    el('div', { class: 'zone' }, zoneList('Player Hand', p.hand.cards, { clickCard: async (c)=>{ if (!await game.playFromHand(p, c.id)) { /* ignore */ } onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip }))
   );
   const enemyRow = el('div', { class: 'row enemy' },
     heroPane(e.hero),


### PR DESCRIPTION
## Summary
- add in-game target selection overlay for effects needing a target
- make effect execution and play flow async to await chosen targets
- update tests for new targeting behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bea987062c8323a93150e3d1ba9596