### PR TITLE
fix: enable Lightning Bolt targeting

### DIFF
--- a/__tests__/lightning-bolt.targeting.test.js
+++ b/__tests__/lightning-bolt.targeting.test.js
@@ -1,0 +1,33 @@
+import { jest } from '@jest/globals';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('playing Lightning Bolt prompts for a target', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  // Clean zones for determinism
+  g.player.hand.cards = [];
+  g.opponent.battlefield.cards = [];
+
+  // Ensure sufficient resources
+  g.resources._pool.set(g.player, 10);
+
+  // Add an enemy to target
+  const enemy = new Card({ name: 'Target Dummy', type: 'ally', data: { attack: 0, health: 5 }, keywords: [] });
+  g.opponent.battlefield.add(enemy);
+
+  // Add Lightning Bolt to hand
+  g.addCardToHand('spell-lightning-bolt');
+  const bolt = g.player.hand.cards.find(c => c.id === 'spell-lightning-bolt');
+
+  // Spy on target prompt
+  const promptSpy = jest.fn(async () => enemy);
+  g.promptTarget = promptSpy;
+
+  await g.playFromHand(g.player, bolt.id);
+
+  expect(promptSpy).toHaveBeenCalled();
+  expect(enemy.data.health).toBe(2); // 5 - 3 damage
+});
+

--- a/data/cards.json
+++ b/data/cards.json
@@ -342,6 +342,11 @@
     "cost": 1,
     "effects": [
       {
+        "type": "damage",
+        "amount": 3,
+        "target": "any"
+      },
+      {
         "type": "overload",
         "amount": 1
       }

--- a/live-reload.json
+++ b/live-reload.json
@@ -1,1 +1,1 @@
-{"version":"ffd096da","time":1757325895877}
+{"version":"ffd096da","time":1757326408110}


### PR DESCRIPTION
## Summary
- add damage effect to Lightning Bolt so it prompts for a target
- test that Lightning Bolt triggers target selection and deals damage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beabf5842083238999ec4ea6d45dff