### PR TITLE
feat: move target prompt styles to stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>WoW Legends</title>
+    <link rel="stylesheet" href="styles.css" />
     <style>
       html, body { height: 100%; margin: 0; font-family: system-ui, sans-serif; background: #0b0f14; color: #e5eef8; }
       #app { min-height: 100%; display: flex; flex-direction: column; }

--- a/live-reload.json
+++ b/live-reload.json
@@ -1,1 +1,1 @@
-{"version":"ffd096da","time":1757326408110}
+{"version":"ffd096da","time":1757327488989}

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -186,26 +186,12 @@ export default class Game {
     return new Promise((resolve) => {
       const overlay = document.createElement('div');
       overlay.className = 'target-prompt';
-      overlay.style.position = 'fixed';
-      overlay.style.top = '0';
-      overlay.style.left = '0';
-      overlay.style.right = '0';
-      overlay.style.bottom = '0';
-      overlay.style.background = 'rgba(0,0,0,0.5)';
-      overlay.style.display = 'flex';
-      overlay.style.alignItems = 'center';
-      overlay.style.justifyContent = 'center';
 
       const list = document.createElement('ul');
-      list.style.background = '#fff';
-      list.style.padding = '1em';
-      list.style.listStyle = 'none';
 
       candidates.forEach((t) => {
         const li = document.createElement('li');
         li.textContent = t.name;
-        li.style.cursor = 'pointer';
-        li.style.margin = '0.25em 0';
         li.addEventListener('click', () => {
           document.body.removeChild(overlay);
           resolve(t);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,23 @@
+.target-prompt {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.target-prompt ul {
+  background: #0b0f14;
+  list-style: none;
+  padding: 1em;
+}
+
+.target-prompt li {
+  cursor: pointer;
+  margin: 0.25em 0;
+  padding: 4px 6px;
+}


### PR DESCRIPTION
## Summary
- style target prompt overlay and list via new `styles.css`
- reference external stylesheet in `index.html`
- adjust target list background and padding

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beb018535c8323afb7dbbacfc5faaf