### PR TITLE
refactor: move inline styles to stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,18 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>WoW Legends</title>
     <link rel="stylesheet" href="styles.css" />
-    <style>
-      html, body { height: 100%; margin: 0; font-family: system-ui, sans-serif; background: #0b0f14; color: #e5eef8; }
-      #app { min-height: 100%; display: flex; flex-direction: column; }
-      header { padding: 8px 12px; background: #111923; border-bottom: 1px solid #203040; }
-      main { flex: 1; padding: 12px; display: grid; grid-template-columns: 3fr 1fr; gap: 12px; }
-      footer { padding: 8px 12px; font-size: 12px; opacity: 0.7; border-top: 1px solid #203040; }
-      .row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
-      .zone { background: #10171f; padding: 8px; border: 1px solid #203040; border-radius: 4px; }
-      ul.zone-list { margin: 0; padding: 0; list-style: none; }
-      ul.zone-list li { padding: 4px 6px; margin: 2px 0; background: #172230; cursor: pointer; border-radius: 3px; }
-      .controls { margin: 8px 0; }
-    </style>
   </head>
   <body>
     <div id="app">

--- a/live-reload.json
+++ b/live-reload.json
@@ -1,1 +1,1 @@
-{"version":"ffd096da","time":1757327488989}
+{"version":"ffd096da","time":1757327822160}

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,69 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: #0b0f14;
+  color: #e5eef8;
+}
+
+#app {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  padding: 8px 12px;
+  background: #111923;
+  border-bottom: 1px solid #203040;
+}
+
+main {
+  flex: 1;
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  gap: 12px;
+}
+
+footer {
+  padding: 8px 12px;
+  font-size: 12px;
+  opacity: 0.7;
+  border-top: 1px solid #203040;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+
+.zone {
+  background: #10171f;
+  padding: 8px;
+  border: 1px solid #203040;
+  border-radius: 4px;
+}
+
+ul.zone-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+ul.zone-list li {
+  padding: 4px 6px;
+  margin: 2px 0;
+  background: #172230;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.controls {
+  margin: 8px 0;
+}
+
 .target-prompt {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- move layout and base styles from index.html into styles.css to centralize styling
- keep index.html free of inline style definitions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beb19044f88323a83e25136724e7ba