### PR TITLE
feat: implement Scarlet Sorcerer spell damage aura

### DIFF
--- a/__tests__/scarlet-sorcerer.spell-damage.test.js
+++ b/__tests__/scarlet-sorcerer.spell-damage.test.js
@@ -1,0 +1,28 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('Scarlet Sorcerer increases spell damage by 1', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+
+  const sorcData = g.allCards.find(c => c.id === 'ally-scarlet-sorcerer');
+  const sorc = new Card(sorcData);
+  g.player.battlefield.add(sorc);
+
+  g.addCardToHand('spell-lightning-bolt');
+  const bolt = g.player.hand.cards.find(c => c.id === 'spell-lightning-bolt');
+
+  const enemy = new Card({ name: 'Dummy', type: 'ally', data: { attack: 0, health: 5 }, keywords: [] });
+  g.opponent.battlefield.add(enemy);
+  g.promptTarget = async () => enemy;
+
+  await g.playFromHand(g.player, bolt.id);
+
+  expect(enemy.data.health).toBe(1);
+});
+

--- a/data/cards.json
+++ b/data/cards.json
@@ -806,7 +806,8 @@
     ],
     "data": {
       "attack": 3,
-      "health": 3
+      "health": 3,
+      "spellDamage": 1
     },
     "text": "Spell Damage +1."
   },

--- a/live-reload.json
+++ b/live-reload.json
@@ -1,1 +1,1 @@
-{"version":"fb7a7a14","time":1757332143553}
+{"version":"ef2f09dd","time":1757343967927}

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -1,6 +1,6 @@
 import Card from '../entities/card.js';
 import Equipment from '../entities/equipment.js';
-import { freezeTarget } from './keywords.js';
+import { freezeTarget, getSpellDamageBonus } from './keywords.js';
 
 export class EffectSystem {
   constructor(game) {
@@ -64,11 +64,15 @@ export class EffectSystem {
 
   async dealDamage(effect, context) {
     const { target, amount, freeze, beastBonus } = effect;
-    const { game, player } = context;
+    const { game, player, card } = context;
     let dmgAmount = amount;
     if (beastBonus) {
       const hasBeast = player.battlefield.cards.some(c => c.keywords?.includes('Beast'));
       if (hasBeast) dmgAmount += beastBonus;
+    }
+    if (card?.type === 'spell') {
+      const bonus = getSpellDamageBonus(player);
+      if (bonus) dmgAmount += bonus;
     }
 
     let actualTargets = [];

--- a/src/js/systems/keywords.js
+++ b/src/js/systems/keywords.js
@@ -35,6 +35,18 @@ export function computeSpellDamage(base, spellDamage = 0) {
   return base + (spellDamage || 0);
 }
 
+export function getSpellDamageBonus(player) {
+  let bonus = 0;
+  if (player?.hero?.data?.spellDamage) bonus += player.hero.data.spellDamage;
+  if (player?.hero?.equipment) {
+    bonus += player.hero.equipment.reduce((s, e) => s + (e.spellDamage || 0), 0);
+  }
+  if (player?.battlefield?.cards) {
+    bonus += player.battlefield.cards.reduce((s, c) => s + (c.data?.spellDamage || 0), 0);
+  }
+  return bonus;
+}
+
 export function applyLayers(value, modifiers = []) {
   // modifiers: array of {priority, apply: (v)=>v}
   return modifiers


### PR DESCRIPTION
## Summary
- add spell damage bonus tracking and apply it to spell damage
- grant Scarlet Sorcerer a +1 spell damage aura
- test that spells deal extra damage when the sorcerer is on the battlefield

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bef000de708323beaa27d8e24a2bc7