### PR TITLE
fix: spell damage boosts all damaging spells

### DIFF
--- a/__tests__/whirlwind.spell-damage.test.js
+++ b/__tests__/whirlwind.spell-damage.test.js
@@ -1,0 +1,33 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('Spell Damage +1 from Scarlet Sorcerer boosts Whirlwind', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  // Clear zones for controlled scenario
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+
+  // Add Scarlet Sorcerer to grant Spell Damage +1
+  const sorcData = g.allCards.find(c => c.id === 'ally-scarlet-sorcerer');
+  const sorc = new Card(sorcData);
+  g.player.battlefield.add(sorc);
+
+  // Add Whirlwind to hand
+  g.addCardToHand('spell-whirlwind');
+  const whirlwind = g.player.hand.cards.find(c => c.id === 'spell-whirlwind');
+
+  // Add an enemy minion to verify AoE damage
+  const enemy = new Card({ name: 'Dummy', type: 'ally', data: { attack: 0, health: 3 }, keywords: [] });
+  g.opponent.battlefield.add(enemy);
+
+  const initialHeroHealth = g.opponent.hero.data.health;
+
+  await g.playFromHand(g.player, whirlwind.id);
+
+  expect(enemy.data.health).toBe(1); // took 2 damage instead of 1
+  expect(g.opponent.hero.data.health).toBe(initialHeroHealth - 2);
+});

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -1,6 +1,6 @@
 import Card from '../entities/card.js';
 import Equipment from '../entities/equipment.js';
-import { freezeTarget, getSpellDamageBonus } from './keywords.js';
+import { freezeTarget, getSpellDamageBonus, computeSpellDamage } from './keywords.js';
 
 export class EffectSystem {
   constructor(game) {
@@ -71,15 +71,15 @@ export class EffectSystem {
   async dealDamage(effect, context) {
     const { target, amount, freeze, beastBonus } = effect;
     const { game, player, card } = context;
-    let dmgAmount = amount;
-    if (beastBonus) {
-      const hasBeast = player.battlefield.cards.some(c => c.keywords?.includes('Beast'));
-      if (hasBeast) dmgAmount += beastBonus;
-    }
-    if (card?.type === 'spell') {
-      const bonus = getSpellDamageBonus(player);
-      if (bonus) dmgAmount += bonus;
-    }
+      let dmgAmount = amount;
+      if (beastBonus) {
+        const hasBeast = player.battlefield.cards.some(c => c.keywords?.includes('Beast'));
+        if (hasBeast) dmgAmount += beastBonus;
+      }
+      if (card?.type === 'spell') {
+        const bonus = getSpellDamageBonus(player);
+        if (bonus) dmgAmount = computeSpellDamage(amount, bonus);
+      }
 
     let actualTargets = [];
 


### PR DESCRIPTION
## Summary
- use computeSpellDamage helper when resolving spell damage effects
- test that Scarlet Sorcerer's Spell Damage +1 increases Whirlwind's damage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf254266148323a1c1341ea32edb69