### PR TITLE
feat: implement hero active and passive effects

### DIFF
--- a/__tests__/hero.effects.test.js
+++ b/__tests__/hero.effects.test.js
@@ -1,0 +1,36 @@
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+
+describe('hero effects', () => {
+  test('passive effect triggers at start of each turn', async () => {
+    const g = new Game();
+    g.player.hero = new Hero({ passive: [{ type: 'buff', target: 'hero', property: 'armor', amount: 1 }] });
+    g.turns.setActivePlayer(g.player);
+    g.turns.startTurn();
+    await Promise.resolve();
+    expect(g.player.hero.data.armor).toBe(1);
+
+    g.turns.bus.emit('turn:start', { player: g.player });
+    await Promise.resolve();
+    expect(g.player.hero.data.armor).toBe(2);
+  });
+
+  test('active effect can be used once per turn', async () => {
+    const g = new Game();
+    g.player.hero = new Hero({ active: [{ type: 'buff', target: 'hero', property: 'armor', amount: 1 }] });
+    g.turns.setActivePlayer(g.player);
+    g.turns.bus.emit('turn:start', { player: g.player });
+    await Promise.resolve();
+
+    await g.useHeroPower(g.player);
+    expect(g.player.hero.data.armor).toBe(1);
+    await g.useHeroPower(g.player);
+    expect(g.player.hero.data.armor).toBe(1);
+
+    g.turns.bus.emit('turn:start', { player: g.player });
+    await Promise.resolve();
+    await g.useHeroPower(g.player);
+    expect(g.player.hero.data.armor).toBe(2);
+  });
+});
+

--- a/src/js/entities/hero.js
+++ b/src/js/entities/hero.js
@@ -1,7 +1,7 @@
 import { shortId } from '../utils/id.js';
 
 export default class Hero {
-  constructor({ id, name = 'Hero', data = {}, attack = 0, health = 30, armor = 0, keywords = [], text = '', effects = [] } = {}) {
+  constructor({ id, name = 'Hero', data = {}, attack = 0, health = 30, armor = 0, keywords = [], text = '', effects = [], active = effects, passive = [] } = {}) {
     this.id = id || shortId('hero');
     this.name = name;
     if (data) {
@@ -11,9 +11,14 @@ export default class Hero {
     }
     this.data = { attack, health, armor };
     this.keywords = keywords;
-    this.effects = effects;
+    this.active = active; // hero power (active ability)
+    this.passive = passive; // passive effects applied automatically
     this.text = text;
     this.equipment = [];
+    this.powerUsed = false; // track hero power usage per turn
+
+    // Backwards compatibility: some code may still reference `.effects`
+    this.effects = this.active;
   }
 
   totalAttack() {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -28,6 +28,12 @@ export default class Game {
     this.turns.bus.on('turn:start', ({ player }) => {
       const bonus = player?.hero?.data?.nextSpellDamageBonus;
       if (bonus?.eachTurn) bonus.used = false;
+      if (player?.hero) {
+        player.hero.powerUsed = false;
+        if (player.hero.passive?.length) {
+          this.effects.execute(player.hero.passive, { game: this, player, card: player.hero });
+        }
+      }
     });
 
     // Players
@@ -120,6 +126,15 @@ export default class Game {
     const drawn = player.library.draw(n);
     for (const c of drawn) player.hand.add(c);
     return drawn.length;
+  }
+
+  async useHeroPower(player) {
+    const hero = player?.hero;
+    if (!hero || hero.powerUsed) return false;
+    if (!hero.active?.length) return false;
+    await this.effects.execute(hero.active, { game: this, player, card: hero });
+    hero.powerUsed = true;
+    return true;
   }
 
   addCardToHand(cardId) {

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -103,6 +103,7 @@ export function renderPlay(container, game, { onUpdate } = {}) {
     el('button', { onclick: () => { game.draw(p, 1); onUpdate?.(); } }, 'Draw'),
     el('button', { onclick: () => { onUpdate?.(); } }, 'Refresh'),
     el('button', { onclick: () => { game.resolveCombat(p, e); onUpdate?.(); } }, 'Resolve Combat'),
+    el('button', { onclick: async () => { await game.useHeroPower(p); onUpdate?.(); } }, 'Hero Power'),
     el('button', { onclick: async () => { await game.endTurn(); onUpdate?.(); } }, 'End Turn')
   );
 


### PR DESCRIPTION
## Summary
- add support for hero active and passive effects
- allow hero power to be used once per turn and reset on new turns
- expose hero power via play UI and cover with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf3227b734832399688964d6310969