### PR TITLE
feat: add overload to Thrall hero power

### DIFF
--- a/CARDS.md
+++ b/CARDS.md
@@ -84,7 +84,7 @@ Conventions
 
 2) Thrall, Warchief of the Horde
 - Type: Hero — Shaman (Horde)
-- Health: 30; Text: Power (2): Chain Spark — Deal 1 damage to up to three different targets.
+- Health: 30; Text: Power (2): Chain Spark — Deal 1 damage to up to three different targets. Overload (1).
 - Rarity: Legendary
 - Keywords: Overload +1 the turn after using Power.
 - Systems: Elemental/Totem/Enhancement talents scale Overload payoff and Totem summons. Horde reputation adds Warsong and Frostwolf allies.

--- a/__tests__/thrall.hero-power.test.js
+++ b/__tests__/thrall.hero-power.test.js
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+
+const cards = JSON.parse(fs.readFileSync(new URL('../data/cards.json', import.meta.url)));
+const thrallData = cards.find(c => c.id === 'hero-thrall-warchief-of-the-horde');
+
+test("Thrall's hero power applies Overload 1", async () => {
+  const g = new Game();
+  await g.setupMatch();
+  g.player.hero = new Hero(thrallData);
+  g.promptTarget = async () => null;
+  await g.useHeroPower(g.player);
+  expect(g.resources._overloadNext.get(g.player)).toBe(1);
+  g.turns.turn = 2;
+  g.resources.startTurn(g.player);
+  expect(g.resources.pool(g.player)).toBe(1);
+});

--- a/data/cards.json
+++ b/data/cards.json
@@ -27,13 +27,17 @@
         "type": "damage",
         "target": "upToThreeTargets",
         "amount": 1
+      },
+      {
+        "type": "overload",
+        "amount": 1
       }
     ],
     "keywords": [
       "Overload +1 the turn after using Power."
     ],
     "data": {},
-    "text": "Chain Spark — Deal 1 damage to up to three different targets."
+    "text": "Chain Spark — Deal 1 damage to up to three different targets. Overload (1)."
   },
   {
     "id": "hero-varian-wrynn-high-king",


### PR DESCRIPTION
## Summary
- add overload (1) to Thrall's Chain Spark hero power
- document Thrall's hero power overload
- test hero power triggers overload on next turn

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf3471ab308323a711831bab35cd92