### PR TITLE
feat: add gnomish tinkerer consumable effect

### DIFF
--- a/CARDS.md
+++ b/CARDS.md
@@ -370,8 +370,8 @@ Conventions
 - Type: Ally — Gnome (Neutral)
 - Cost: 2; Rarity: Common
 - Stats: 2 ATK / 1 HP
-- Text: Battlecry — Discover a Consumable from your deck (draw it).
-- Keywords: Discover, Tutor
+- Text: Battlecry — Play a random Consumable from your deck.
+- Keywords: Tutor
 - Systems: Supports combo turns; PvE toolbox consistency.
 - Art: Goggles askew, a tinker brandishes a bubbling vial and wrench.
 

--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -205,6 +205,15 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         expect(g.player.hero.data.nextSpellDamageBonus.amount).toBe(effect.amount);
         break;
       }
+      case 'playRandomConsumableFromLibrary': {
+        const consumable = g.allCards.find(c => c.type === 'consumable');
+        g.player.library.cards = [new Card(consumable)];
+        g.player.hero.data.maxHealth = 30;
+        g.player.hero.data.health = 20;
+        await g.playFromHand(g.player, card.id);
+        expect(g.player.graveyard.cards.some(c => c.id === consumable.id)).toBe(true);
+        break;
+      }
       default:
         throw new Error('Unhandled effect type: ' + effect.type);
     }

--- a/__tests__/gnomish-tinkerer.test.js
+++ b/__tests__/gnomish-tinkerer.test.js
@@ -1,0 +1,34 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+describe('Gnomish Tinkerer', () => {
+  test('plays a random consumable from the library', async () => {
+    const g = new Game();
+    await g.setupMatch();
+    g.turns.turn = 10;
+    g.resources._pool.set(g.player, 10);
+
+    // Reset zones for deterministic state
+    g.player.hand.cards = [];
+    g.player.library.cards = [];
+    g.player.graveyard.cards = [];
+    g.player.battlefield.cards = [];
+
+    g.player.hero.data.maxHealth = 30;
+    g.player.hero.data.health = 20;
+
+    g.addCardToHand('ally-gnomish-tinkerer');
+
+    const potionData = g.allCards.find(c => c.id === 'consumable-healing-potion');
+    g.player.library.add(new Card(potionData));
+    const filler = g.allCards.find(c => c.type === 'spell');
+    g.player.library.add(new Card(filler));
+
+    await g.playFromHand(g.player, 'ally-gnomish-tinkerer');
+
+    expect(g.player.hero.data.health).toBe(25);
+    expect(g.player.graveyard.cards.some(c => c.id === 'consumable-healing-potion')).toBe(true);
+    expect(g.player.library.cards.find(c => c.id === 'consumable-healing-potion')).toBeUndefined();
+  });
+});
+

--- a/data/cards.json
+++ b/data/cards.json
@@ -739,19 +739,17 @@
     "cost": 2,
     "effects": [
       {
-        "type": "rawText",
-        "text": "Battlecry — Discover a Consumable from your deck (draw it)."
+        "type": "playRandomConsumableFromLibrary"
       }
     ],
     "keywords": [
-      "Discover",
       "Tutor"
     ],
     "data": {
       "attack": 2,
       "health": 1
     },
-    "text": "Battlecry — Discover a Consumable from your deck (draw it)."
+    "text": "Battlecry — Play a random Consumable from your deck."
   },
   {
     "id": "ally-argent-healer",

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -44,6 +44,9 @@ export class EffectSystem {
         case 'draw':
           this.drawCard(effect, context);
           break;
+        case 'playRandomConsumableFromLibrary':
+          await this.playRandomConsumableFromLibrary(effect, context);
+          break;
         case 'destroy':
           this.destroyMinion(effect, context);
           break;
@@ -281,6 +284,19 @@ export class EffectSystem {
     } else {
       console.log('No player ally found to transform.');
     }
+  }
+
+  async playRandomConsumableFromLibrary(effect, context) {
+    const { player, game } = context;
+    const consumables = player.library.cards.filter(c => c.type === 'consumable');
+    if (!consumables.length) return;
+    const card = game.rng.pick(consumables);
+    player.library.removeById(card.id);
+    player.hand.add(card);
+    const originalCost = card.cost || 0;
+    card.cost = 0;
+    await game.playFromHand(player, card.id);
+    card.cost = originalCost;
   }
 
   registerDefaults() {


### PR DESCRIPTION
## Summary
- implement effect to pull and play a random consumable from the library
- define Gnomish Tinkerer's battlecry using the new effect
- document the card and add tests for the new behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf38b23684832392644c161448f937