### PR TITLE
feat: allow heroes on battlefield

### DIFF
--- a/__tests__/hero.attack.test.js
+++ b/__tests__/hero.attack.test.js
@@ -1,0 +1,14 @@
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+
+test('hero can attack when toggled', () => {
+  const g = new Game();
+  g.player.hero = new Hero({ name: 'Hero', data: { attack: 2, health: 10 } });
+  g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
+  g.player.battlefield.cards = [];
+  g.opponent.battlefield.cards = [];
+
+  expect(g.toggleAttacker(g.player, g.player.hero.id)).toBe(true);
+  g.resolveCombat(g.player, g.opponent);
+  expect(g.opponent.hero.data.health).toBe(8);
+});

--- a/__tests__/ui.board.test.js
+++ b/__tests__/ui.board.test.js
@@ -3,8 +3,8 @@ import { renderBoard, wireInteractions } from '../src/js/ui/board.js';
 import Player from '../src/js/entities/player.js';
 import Card from '../src/js/entities/card.js';
 
-describe('UI Board', () => {
-  test('clicking library draws to hand; clicking hand moves to resources', () => {
+  describe('UI Board', () => {
+    test('clicking library draws to hand; clicking hand moves to resources', () => {
     const container = document.createElement('div');
     const p = new Player({ name: 'U' });
     const c = new Card({ type: 'ally', name: 'A' });
@@ -19,6 +19,14 @@ describe('UI Board', () => {
     const handItem = container.querySelector('ul[data-zone="hand"] li');
     handItem.click();
     expect(p.resourcesZone.size()).toBe(1);
+    });
+
+    test('hero appears in battlefield zone', () => {
+      const container = document.createElement('div');
+      const p = new Player({ name: 'U' });
+      renderBoard(container, p);
+      const bfItems = container.querySelectorAll('ul[data-zone="battlefield"] li');
+      expect(Array.from(bfItems).map(li => li.textContent)).toContain(p.hero.name);
+    });
   });
-});
 

--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -158,5 +158,23 @@ describe('UI Play', () => {
     Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: prevW });
     Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: prevH });
   });
+
+  test('includes hero in battlefield zone list', () => {
+    const container = document.createElement('div');
+    const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
+    const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 } });
+
+    const game = {
+      player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      resources: { pool: () => 0, available: () => 0 },
+      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+    };
+
+    renderPlay(container, game);
+
+    const battlefieldList = container.querySelector('.row.player .zone-list');
+    expect(battlefieldList.textContent).toContain('Player Hero');
+  });
 });
 

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -237,7 +237,7 @@ export default class Game {
   }
 
   toggleAttacker(player, cardId) {
-    const card = player.battlefield.cards.find(c => c.id === cardId);
+    const card = [player.hero, ...player.battlefield.cards].find(c => c.id === cardId);
     if (!card) return false;
     if (this.attacking.has(cardId)) this.attacking.delete(cardId);
     else this.attacking.add(cardId);
@@ -247,7 +247,7 @@ export default class Game {
   resolveCombat(attacker = this.player, defender = this.opponent) {
     this.combat.clear();
     for (const id of this.attacking) {
-      const card = attacker.battlefield.cards.find(c => c.id === id);
+      const card = [attacker.hero, ...attacker.battlefield.cards].find(c => c.id === id);
       if (card) this.combat.declareAttacker(card);
     }
     this.combat.setDefenderHero(defender.hero);

--- a/src/js/ui/board.js
+++ b/src/js/ui/board.js
@@ -6,7 +6,7 @@ export function renderBoard(container, player) {
     ['Library', player.library],
     ['Hand', player.hand],
     ['Resources', player.resourcesZone],
-    ['Battlefield', player.battlefield],
+    ['Battlefield', { cards: [player.hero, ...player.battlefield.cards] }],
     ['Graveyard', player.graveyard],
   ];
   for (const [name, zone] of zones) {

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -109,12 +109,12 @@ export function renderPlay(container, game, { onUpdate } = {}) {
 
   const playerRow = el('div', { class: 'row player' },
     heroPane(p.hero),
-    el('div', { class: 'zone' }, zoneList('Player Battlefield', p.battlefield.cards, { clickCard: (c)=>{ game.toggleAttacker(p, c.id); onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
+    el('div', { class: 'zone' }, zoneList('Player Battlefield', [p.hero, ...p.battlefield.cards], { clickCard: (c)=>{ game.toggleAttacker(p, c.id); onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
     el('div', { class: 'zone' }, zoneList('Player Hand', p.hand.cards, { clickCard: async (c)=>{ if (!await game.playFromHand(p, c.id)) { /* ignore */ } onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip }))
   );
   const enemyRow = el('div', { class: 'row enemy' },
     heroPane(e.hero),
-    el('div', { class: 'zone' }, zoneList('Enemy Battlefield', e.battlefield.cards, { game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
+    el('div', { class: 'zone' }, zoneList('Enemy Battlefield', [e.hero, ...e.battlefield.cards], { game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
     el('div', { class: 'zone' }, el('h3', {}, 'Enemy Hand'), el('p', {}, `${e.hand.size()} cards`))
   );
 


### PR DESCRIPTION
## Summary
- allow selecting the hero for combat by treating it like a battlefield card
- show heroes inside battlefield zones in the play and board UIs
- cover hero battlefield behavior with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf3d6eb6f48323b70ce32304cf6c2e