### PR TITLE
feat: add choose one hero power mechanic

### DIFF
--- a/__tests__/malfurion.hero-power.test.js
+++ b/__tests__/malfurion.hero-power.test.js
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+
+const cards = JSON.parse(fs.readFileSync(new URL('../data/cards.json', import.meta.url)));
+const malfData = cards.find(c => c.id === 'hero-malfurion-stormrage-archdruid');
+
+test("Malfurion's hero power can grant attack", async () => {
+  const g = new Game();
+  await g.setupMatch();
+  g.player.hero = new Hero(malfData);
+  g.promptOption = async () => 0; // choose attack option
+  await g.useHeroPower(g.player);
+  expect(g.player.hero.data.attack).toBe(1);
+  expect(g.player.hero.data.armor).toBe(0);
+});
+
+test("Malfurion's hero power can grant armor", async () => {
+  const g = new Game();
+  await g.setupMatch();
+  g.player.hero = new Hero(malfData);
+  g.promptOption = async () => 1; // choose armor option
+  await g.useHeroPower(g.player);
+  expect(g.player.hero.data.attack).toBe(0);
+  expect(g.player.hero.data.armor).toBe(2);
+});

--- a/data/cards.json
+++ b/data/cards.json
@@ -135,17 +135,32 @@
     "type": "hero",
     "effects": [
       {
-        "type": "buff",
-        "target": "hero",
-        "property": "attack",
-        "amount": 1,
-        "duration": "thisTurn"
-      },
-      {
-        "type": "buff",
-        "target": "hero",
-        "property": "armor",
-        "amount": 2
+        "type": "chooseOne",
+        "options": [
+          {
+            "text": "+1 ATK this turn",
+            "effects": [
+              {
+                "type": "buff",
+                "target": "hero",
+                "property": "attack",
+                "amount": 1,
+                "duration": "thisTurn"
+              }
+            ]
+          },
+          {
+            "text": "Gain 2 Armor",
+            "effects": [
+              {
+                "type": "buff",
+                "target": "hero",
+                "property": "armor",
+                "amount": 2
+              }
+            ]
+          }
+        ]
       }
     ],
     "keywords": [

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -236,6 +236,32 @@ export default class Game {
     });
   }
 
+  async promptOption(options) {
+    if (!options?.length) return 0;
+    if (typeof document === 'undefined') {
+      return 0;
+    }
+    return new Promise((resolve) => {
+      const overlay = document.createElement('div');
+      overlay.className = 'option-prompt';
+
+      const list = document.createElement('ul');
+
+      options.forEach((t, idx) => {
+        const li = document.createElement('li');
+        li.textContent = t;
+        li.addEventListener('click', () => {
+          document.body.removeChild(overlay);
+          resolve(idx);
+        });
+        list.appendChild(li);
+      });
+
+      overlay.appendChild(list);
+      document.body.appendChild(overlay);
+    });
+  }
+
   toggleAttacker(player, cardId) {
     const card = [player.hero, ...player.battlefield.cards].find(c => c.id === cardId);
     if (!card) return false;

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -65,6 +65,9 @@ export class EffectSystem {
         case 'damageArmor':
           await this.dealDamage({ target: effect.target, amount: context.player.hero.data.armor }, context);
           break;
+        case 'chooseOne':
+          await this.handleChooseOne(effect, context);
+          break;
         default:
           console.log(`Unknown effect type: ${effect.type}`);
       }
@@ -391,6 +394,16 @@ export class EffectSystem {
     console.log('applyOverload: game.resources', game.resources);
     game.resources.addOverloadNextTurn(player, amount);
     console.log(`Applied ${amount} overload to ${player.name}.`);
+  }
+
+  async handleChooseOne(effect, context) {
+    const { game } = context;
+    const optionTexts = effect.options?.map(o => o.text) || [];
+    const idx = await game.promptOption(optionTexts);
+    const chosen = effect.options?.[idx] || effect.options?.[0];
+    if (chosen?.effects) {
+      await this.execute(chosen.effects, context);
+    }
   }
 
   restoreResources(effect, context) {


### PR DESCRIPTION
## Summary
- allow hero powers to present selectable options
- implement choose-one handling in effect system
- cover Malfurion shapeshift options with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfb61aa7e88323a88ff411d7c9237a