### PR TITLE
chore: enable ESLint for JavaScript files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "http-server": "^14.1.1"
       },
       "devDependencies": {
+        "@eslint/js": "^9.35.0",
         "eslint": "^9.35.0",
         "globals": "^16.3.0",
         "htmlhint": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:coverage": "npm run test -- --coverage",
     "simulate": "node tools/simulate.mjs",
     "ingest": "node tools/cards-ingest.mjs",
-    "lint": "eslint . --ext .js,.mjs && htmlhint index.html"
+    "lint": "eslint . --ext .js,.mjs && echo ESLint scanned $(git ls-files '*.js' '*.mjs' | wc -l) JS files && htmlhint index.html"
   },
   "keywords": [],
   "author": "AI Agents",
@@ -22,6 +22,7 @@
     "http-server": "^14.1.1"
   },
   "devDependencies": {
+    "@eslint/js": "^9.35.0",
     "eslint": "^9.35.0",
     "globals": "^16.3.0",
     "htmlhint": "^1.1.4",


### PR DESCRIPTION
## Summary
- add missing `@eslint/js` dev dependency
- show number of JavaScript files linted in `npm run lint`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb6476f108323bf47ed1da653cca6