### PR TITLE
feat: allow early completion in multi-target selection

### DIFF
--- a/__tests__/no-more-targets.targeting.test.js
+++ b/__tests__/no-more-targets.targeting.test.js
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('multi-target prompts allow early completion after first pick', async () => {
+  const g = new Game();
+  const player = g.player;
+  const enemy1 = new Card({ name: 'E1', type: 'ally', data: { attack: 0, health: 2 }, keywords: [] });
+  const enemy2 = new Card({ name: 'E2', type: 'ally', data: { attack: 0, health: 2 }, keywords: [] });
+  g.opponent.battlefield.add(enemy1);
+  g.opponent.battlefield.add(enemy2);
+
+  const promptSpy = jest
+    .fn()
+    .mockResolvedValueOnce(enemy1)
+    .mockResolvedValueOnce(null);
+  g.promptTarget = promptSpy;
+
+  await g.effects.dealDamage(
+    { target: 'upToThreeTargets', amount: 1 },
+    { game: g, player, card: null }
+  );
+
+  expect(promptSpy).toHaveBeenCalledTimes(2);
+  expect(promptSpy.mock.calls[0][1]).toEqual({ allowNoMore: false });
+  expect(promptSpy.mock.calls[1][1]).toEqual({ allowNoMore: true });
+  expect(enemy1.data.health).toBe(1);
+  expect(enemy2.data.health).toBe(2);
+});

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -210,7 +210,7 @@ export default class Game {
     return true;
   }
 
-  async promptTarget(candidates) {
+  async promptTarget(candidates, { allowNoMore = false } = {}) {
     if (!candidates?.length) return null;
     if (typeof document === 'undefined') {
       return candidates[0];
@@ -232,6 +232,17 @@ export default class Game {
       });
 
       overlay.appendChild(list);
+
+      if (allowNoMore) {
+        const done = document.createElement('button');
+        done.textContent = 'No more targets';
+        done.addEventListener('click', () => {
+          document.body.removeChild(overlay);
+          resolve(null);
+        });
+        overlay.appendChild(done);
+      }
+
       document.body.appendChild(overlay);
     });
   }

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -121,7 +121,10 @@ export class EffectSystem {
         ];
         const chosen = new Set();
         for (let i = 0; i < 3; i++) {
-          const pick = await game.promptTarget(candidates.filter(c => !chosen.has(c)));
+          const pick = await game.promptTarget(
+            candidates.filter(c => !chosen.has(c)),
+            { allowNoMore: chosen.size > 0 }
+          );
           if (!pick) break;
           chosen.add(pick);
         }

--- a/styles.css
+++ b/styles.css
@@ -87,3 +87,8 @@ ul.zone-list li {
   margin: 0.25em 0;
   padding: 4px 6px;
 }
+
+.target-prompt button {
+  margin-top: 0.5em;
+  padding: 4px 6px;
+}


### PR DESCRIPTION
## Summary
- add optional "No more targets" button to targeting prompt
- enable multi-target effects to expose early completion
- style the new button and cover with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfb9a4a700832380559534785ba48b