### PR TITLE
feat: charge mana for hero powers

### DIFF
--- a/__tests__/hero-power.cost.test.js
+++ b/__tests__/hero-power.cost.test.js
@@ -1,0 +1,33 @@
+/** @jest-environment jsdom */
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import { renderPlay } from '../src/js/ui/play.js';
+
+const cards = JSON.parse(fs.readFileSync(new URL('../data/cards.json', import.meta.url)));
+const thrallData = cards.find(c => c.id === 'hero-thrall-warchief-of-the-horde');
+
+test('Hero power requires 2 mana', async () => {
+  const g = new Game();
+  g.player.hero = new Hero(thrallData);
+  g.turns.setActivePlayer(g.player);
+  g.turns.turn = 1;
+  g.resources.startTurn(g.player);
+  const result = await g.useHeroPower(g.player);
+  expect(result).toBe(false);
+  expect(g.resources.pool(g.player)).toBe(1);
+  expect(g.player.hero.powerUsed).toBe(false);
+});
+
+test('Hero power button disabled when insufficient mana', async () => {
+  const g = new Game();
+  g.player.hero = new Hero(thrallData);
+  g.opponent.hero = new Hero(thrallData);
+  g.turns.setActivePlayer(g.player);
+  g.turns.turn = 1;
+  g.resources.startTurn(g.player);
+  const container = document.createElement('div');
+  renderPlay(container, g);
+  let btn = [...container.querySelectorAll('button')].find(b => b.textContent === 'Hero Power');
+  expect(btn.disabled).toBe(true);
+});

--- a/__tests__/hero.effects.test.js
+++ b/__tests__/hero.effects.test.js
@@ -21,14 +21,18 @@ describe('hero effects', () => {
     g.turns.setActivePlayer(g.player);
     g.turns.bus.emit('turn:start', { player: g.player });
     await Promise.resolve();
+    g.turns.turn = 2;
+    g.resources.startTurn(g.player);
 
     await g.useHeroPower(g.player);
     expect(g.player.hero.data.armor).toBe(1);
     await g.useHeroPower(g.player);
     expect(g.player.hero.data.armor).toBe(1);
 
+    g.turns.turn++;
     g.turns.bus.emit('turn:start', { player: g.player });
     await Promise.resolve();
+    g.resources.startTurn(g.player);
     await g.useHeroPower(g.player);
     expect(g.player.hero.data.armor).toBe(2);
   });

--- a/__tests__/malfurion.hero-power.test.js
+++ b/__tests__/malfurion.hero-power.test.js
@@ -9,18 +9,24 @@ test("Malfurion's hero power can grant attack", async () => {
   const g = new Game();
   await g.setupMatch();
   g.player.hero = new Hero(malfData);
+  g.turns.turn = 2;
+  g.resources.startTurn(g.player);
   g.promptOption = async () => 0; // choose attack option
   await g.useHeroPower(g.player);
   expect(g.player.hero.data.attack).toBe(1);
   expect(g.player.hero.data.armor).toBe(0);
+  expect(g.resources.pool(g.player)).toBe(0);
 });
 
 test("Malfurion's hero power can grant armor", async () => {
   const g = new Game();
   await g.setupMatch();
   g.player.hero = new Hero(malfData);
+  g.turns.turn = 2;
+  g.resources.startTurn(g.player);
   g.promptOption = async () => 1; // choose armor option
   await g.useHeroPower(g.player);
   expect(g.player.hero.data.attack).toBe(0);
   expect(g.player.hero.data.armor).toBe(2);
+  expect(g.resources.pool(g.player)).toBe(0);
 });

--- a/__tests__/thrall.hero-power.test.js
+++ b/__tests__/thrall.hero-power.test.js
@@ -9,10 +9,13 @@ test("Thrall's hero power applies Overload 1", async () => {
   const g = new Game();
   await g.setupMatch();
   g.player.hero = new Hero(thrallData);
-  g.promptTarget = async () => null;
-  await g.useHeroPower(g.player);
-  expect(g.resources._overloadNext.get(g.player)).toBe(1);
   g.turns.turn = 2;
   g.resources.startTurn(g.player);
-  expect(g.resources.pool(g.player)).toBe(1);
+  g.promptTarget = async () => null;
+  await g.useHeroPower(g.player);
+  expect(g.resources.pool(g.player)).toBe(0);
+  expect(g.resources._overloadNext.get(g.player)).toBe(1);
+  g.turns.turn = 3;
+  g.resources.startTurn(g.player);
+  expect(g.resources.pool(g.player)).toBe(2);
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -132,6 +132,8 @@ export default class Game {
     const hero = player?.hero;
     if (!hero || hero.powerUsed) return false;
     if (!hero.active?.length) return false;
+    const cost = 2;
+    if (!this.resources.pay(player, cost)) return false;
     await this.effects.execute(hero.active, { game: this, player, card: hero });
     hero.powerUsed = true;
     return true;

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -103,7 +103,7 @@ export function renderPlay(container, game, { onUpdate } = {}) {
     el('button', { onclick: () => { game.draw(p, 1); onUpdate?.(); } }, 'Draw'),
     el('button', { onclick: () => { onUpdate?.(); } }, 'Refresh'),
     el('button', { onclick: () => { game.resolveCombat(p, e); onUpdate?.(); } }, 'Resolve Combat'),
-    el('button', { onclick: async () => { await game.useHeroPower(p); onUpdate?.(); } }, 'Hero Power'),
+    el('button', { onclick: async () => { await game.useHeroPower(p); onUpdate?.(); }, disabled: p.hero.powerUsed || game.resources.pool(p) < 2 }, 'Hero Power'),
     el('button', { onclick: async () => { await game.endTurn(); onUpdate?.(); } }, 'End Turn')
   );
 


### PR DESCRIPTION
## Summary
- charge 2 mana when activating hero powers
- disable hero power button if player can't afford the cost
- expand hero power tests for mana usage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd58f373c83238ad6a0057d7c69da