### PR TITLE
feat: apply armor absorption to damage

### DIFF
--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -11,6 +11,9 @@ describe.each(effectCards)('$id executes its effect', (card) => {
     const g = new Game();
     await g.setupMatch();
 
+    g.player.hero.data.armor = 0;
+    g.opponent.hero.data.armor = 0;
+
     // clean zones for deterministic counts
     g.player.hand.cards = [];
     g.opponent.hand.cards = [];

--- a/__tests__/systems.effects.test.js
+++ b/__tests__/systems.effects.test.js
@@ -35,5 +35,39 @@ describe('EffectSystem', () => {
     expect(promptSpy).toHaveBeenCalled();
     expect(enemy.data.health).toBe(1);
   });
+
+  test('armor absorbs damage before health', async () => {
+    const game = new Game();
+    const player = game.player;
+    player.hero.data.armor = 3;
+    player.hero.data.health = 10;
+    game.promptTarget = async () => player.hero;
+
+    await game.effects.dealDamage(
+      { target: 'character', amount: 2 },
+      { game, player, card: null }
+    );
+
+    expect(player.hero.data.armor).toBe(1);
+    expect(player.hero.data.health).toBe(10);
+
+    await game.effects.dealDamage(
+      { target: 'character', amount: 2 },
+      { game, player, card: null }
+    );
+
+    expect(player.hero.data.armor).toBe(0);
+    expect(player.hero.data.health).toBe(9);
+  });
+
+  test('buff can increase armor', async () => {
+    const game = new Game();
+    const player = game.player;
+    await game.effects.applyBuff(
+      { target: 'hero', property: 'armor', amount: 2 },
+      { game, player }
+    );
+    expect(player.hero.data.armor).toBe(2);
+  });
 });
 

--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -4,10 +4,10 @@ import { renderPlay } from '../src/js/ui/play.js';
 import Hero from '../src/js/entities/hero.js';
 
 describe('UI Play', () => {
-  test('renders hero panes with name, health, and abilities', () => {
+  test('renders hero panes with name, health, armor, and abilities', () => {
     const container = document.createElement('div');
-    const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 }, text: 'Player ability', keywords: ['Swift'] });
-    const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 }, text: 'Enemy ability', keywords: ['Stealth'] });
+    const playerHero = new Hero({ name: 'Player Hero', data: { health: 25, armor: 5 }, text: 'Player ability', keywords: ['Swift'] });
+    const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20, armor: 3 }, text: 'Enemy ability', keywords: ['Stealth'] });
 
     const game = {
       player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
@@ -21,11 +21,13 @@ describe('UI Play', () => {
     const playerPane = container.querySelector('.row.player .hero-pane');
     expect(playerPane.textContent).toContain('Player Hero');
     expect(playerPane.textContent).toContain('Health: 25');
+    expect(playerPane.textContent).toContain('Armor: 5');
     expect(playerPane.textContent).toContain('Player ability');
 
     const enemyPane = container.querySelector('.row.enemy .hero-pane');
     expect(enemyPane.textContent).toContain('Enemy Hero');
     expect(enemyPane.textContent).toContain('Health: 20');
+    expect(enemyPane.textContent).toContain('Armor: 3');
     expect(enemyPane.textContent).toContain('Enemy ability');
   });
 

--- a/data/cards.json
+++ b/data/cards.json
@@ -55,7 +55,7 @@
     "keywords": [
       "Armor — Starts with 2 Armor."
     ],
-    "data": {},
+    "data": { "armor": 2 },
     "text": "Heroic Strike — Your hero gains +1 ATK this turn."
   },
   {

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -165,14 +165,21 @@ export class EffectSystem {
     }
 
     for (const t of actualTargets) {
+      let remaining = dmgAmount;
+      if (t.data && typeof t.data.armor === 'number') {
+        const use = Math.min(t.data.armor, remaining);
+        t.data.armor -= use;
+        remaining -= use;
+      }
+      if (remaining <= 0) continue;
       if (t.data && t.data.health != null) {
-        t.data.health -= dmgAmount;
-        console.log(`${t.name} took ${dmgAmount} damage. Remaining health: ${t.data.health}`);
+        t.data.health -= remaining;
+        console.log(`${t.name} took ${remaining} damage. Remaining health: ${t.data.health}`);
         if (t.data.health > 0 && freeze) freezeTarget(t, freeze);
         if (t.data.health <= 0) t.data.dead = true;
       } else if (t.health != null) {
-        t.health -= dmgAmount;
-        console.log(`${t.name} took ${dmgAmount} damage. Remaining health: ${t.health}`);
+        t.health -= remaining;
+        console.log(`${t.name} took ${remaining} damage. Remaining health: ${t.health}`);
         if (t.health > 0 && freeze) freezeTarget(t, freeze);
       }
     }

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -39,7 +39,7 @@ function heroPane(hero) {
   }
   return el('div', { class: 'hero-pane' },
     el('h3', {}, hero.name),
-    el('p', {}, `Health: ${hero.data.health}`),
+    el('p', {}, `Health: ${hero.data.health} Armor: ${hero.data.armor}`),
     ...abilities
   );
 }
@@ -101,7 +101,7 @@ export function renderPlay(container, game, { onUpdate } = {}) {
 
   const header = el('div', { class: 'hud' },
     el('strong', {}, t('app_title')), ' — ',
-    `Your HP ${p.hero.data.health} | Enemy HP ${e.hero.data.health} | Pool ${game.resources.pool(p)} / ${game.resources.available(p)}`
+    `Your HP ${p.hero.data.health} (Armor ${p.hero.data.armor}) | Enemy HP ${e.hero.data.health} (Armor ${e.hero.data.armor}) | Pool ${game.resources.pool(p)} / ${game.resources.available(p)}`
   );
 
   const controls = el('div', { class: 'controls' },


### PR DESCRIPTION
## Summary
- subtract armor before health when damage effects resolve
- start Varian Wrynn with 2 armor
- show hero armor in HUD and hero panes
- test armor buffs and absorption
- reset hero armor in card effect tests for consistency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c009f6f044832387fc223f41e4f2d0