### PR TITLE
feat: apply self damage for Gul'dan hero power

### DIFF
--- a/__tests__/guldan.hero-power.test.js
+++ b/__tests__/guldan.hero-power.test.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+
+const cards = JSON.parse(fs.readFileSync(new URL('../data/cards.json', import.meta.url)));
+const guldanData = cards.find(c => c.id === 'hero-gul-dan-dark-conjurer');
+
+test("Gul'dan's hero power damages his hero", async () => {
+  const g = new Game();
+  await g.setupMatch();
+  g.player.hero = new Hero(guldanData);
+  g.turns.turn = 2;
+  g.resources.startTurn(g.player);
+  const initialHealth = g.player.hero.data.health;
+  await g.useHeroPower(g.player);
+  expect(g.player.hero.data.health).toBe(initialHealth - 2);
+});

--- a/data/cards.json
+++ b/data/cards.json
@@ -194,6 +194,11 @@
       {
         "type": "draw",
         "count": 1
+      },
+      {
+        "type": "damage",
+        "target": "selfHero",
+        "amount": 2
       }
     ],
     "keywords": [

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -159,6 +159,9 @@ export class EffectSystem {
         if (chosen) actualTargets.push(chosen);
         break;
       }
+      case 'selfHero':
+        actualTargets.push(player.hero);
+        break;
       default:
         console.warn(`Unknown damage target: ${target}`);
         return;


### PR DESCRIPTION
## Summary
- allow damage effects to target the caster's hero
- make Gul'dan's Life Tap damage its hero
- cover Gul'dan's hero power with a dedicated test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c01ac4783483238f31d2fa36088279