### PR TITLE
fix: preserve full name for summoned allies

### DIFF
--- a/__tests__/summon.full-name.test.js
+++ b/__tests__/summon.full-name.test.js
@@ -1,0 +1,20 @@
+import Game from '../src/js/game.js';
+
+describe('summoned unit names', () => {
+  test('summoned allies display full name', async () => {
+    const g = new Game();
+    await g.setupMatch();
+    g.turns.turn = 10;
+    g.resources._pool.set(g.player, 10);
+    g.player.hand.cards = [];
+    g.player.battlefield.cards = [];
+
+    g.addCardToHand('spell-summon-infernal');
+    await g.playFromHand(g.player, 'spell-summon-infernal');
+
+    const summoned = g.player.battlefield.cards.find(c => c.name === 'Infernal');
+    expect(summoned).toBeTruthy();
+    expect(summoned.name).toBe('Infernal');
+    expect(summoned.name.length).toBeGreaterThan(1);
+  });
+});

--- a/data/cards.json
+++ b/data/cards.json
@@ -234,7 +234,7 @@
       {
         "type": "summon",
         "unit": {
-          "name": "W",
+          "name": "Water Elemental",
           "attack": 3,
           "health": 6,
           "keywords": []
@@ -442,7 +442,7 @@
       {
         "type": "summon",
         "unit": {
-          "name": "S",
+          "name": "Spirit Wolf",
           "attack": 2,
           "health": 3,
           "keywords": []
@@ -566,7 +566,7 @@
       {
         "type": "summon",
         "unit": {
-          "name": "I",
+          "name": "Infernal",
           "attack": 6,
           "health": 6,
           "keywords": []
@@ -692,7 +692,7 @@
       {
         "type": "summon",
         "unit": {
-          "name": "I",
+          "name": "Imp",
           "attack": 1,
           "health": 1,
           "keywords": []

--- a/tools/cards-ingest.mjs
+++ b/tools/cards-ingest.mjs
@@ -113,7 +113,7 @@ function parseEffect(text, card) {
   }
 
   // Summon effects
-  match = text.match(/Summon (a|two) (\d+)\/(\d+) (.+?)(?: with “(.+?)”|\.)?/i);
+  match = text.match(/Summon (a|two) (\d+)\/(\d+) (.+?)(?= with|\.|$)(?: with “(.+?)”)?/i);
   if (match) {
     const count = match[1] === 'a' ? 1 : 2;
     const attack = parseInt(match[2], 10);


### PR DESCRIPTION
## Summary
- ensure card ingestion captures complete summon names
- list full names for Water Elemental, Spirit Wolf, Infernal and Imp summons
- cover summoned ally names with a regression test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c02d21ae988323aacb275401b1be3c