### PR TITLE
feat: display summoning card in ally tooltip

### DIFF
--- a/__tests__/summon.summoned-by.test.js
+++ b/__tests__/summon.summoned-by.test.js
@@ -1,0 +1,19 @@
+import Game from '../src/js/game.js';
+
+describe('summoned units', () => {
+  test('summoned ally references summoning card', async () => {
+    const g = new Game();
+    await g.setupMatch();
+    g.turns.turn = 10;
+    g.resources._pool.set(g.player, 10);
+    g.player.hand.cards = [];
+    g.player.battlefield.cards = [];
+
+    g.addCardToHand('spell-summon-infernal');
+    await g.playFromHand(g.player, 'spell-summon-infernal');
+
+    const summoned = g.player.battlefield.cards.find(c => c.name === 'Infernal');
+    expect(summoned).toBeTruthy();
+    expect(summoned.summonedBy?.id).toBe('spell-summon-infernal');
+  });
+});

--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -71,6 +71,47 @@ describe('UI Play', () => {
     global.Image = OriginalImage;
   });
 
+  test('summoned allies show summoning card in tooltip', () => {
+    const OriginalImage = global.Image;
+    global.Image = class {
+      constructor() {
+        const img = document.createElement('img');
+        Object.defineProperty(img, 'src', {
+          set(v) {
+            img.setAttribute('src', v);
+            img.onload?.();
+          },
+          get() { return img.getAttribute('src'); }
+        });
+        return img;
+      }
+    };
+
+    const container = document.createElement('div');
+    const summoner = { id: 'spell-summon-infernal', name: 'Summon Infernal', text: 'Summon a 6/6 Infernal.' };
+    const summoned = { id: 'token-infernal', name: 'Infernal', summonedBy: summoner };
+    const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
+    const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 } });
+
+    const game = {
+      player: { hero: playerHero, battlefield: { cards: [summoned] }, hand: { cards: [], size: () => 0 } },
+      opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      resources: { pool: () => 0, available: () => 0 },
+      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+    };
+
+    renderPlay(container, game);
+
+    const li = container.querySelector(`[data-card-id="${summoned.id}"]`);
+    li.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true, clientX: 0, clientY: 0 }));
+
+    const tooltipImg = container.querySelector('.card-tooltip img');
+    expect(tooltipImg).toBeTruthy();
+    expect(tooltipImg.getAttribute('src')).toBe(`src/assets/cards/${summoner.id}.png`);
+
+    global.Image = OriginalImage;
+  });
+
   test('falls back to text tooltip when art is missing', () => {
     const OriginalImage = global.Image;
     global.Image = class {

--- a/src/js/entities/card.js
+++ b/src/js/entities/card.js
@@ -20,6 +20,7 @@ export class CardEntity {
     this.text = props.text || '';
     this.effects = props.effects || [];
     this.combo = props.combo || [];
+    this.summonedBy = props.summonedBy || null;
   }
 }
 

--- a/src/js/entities/types.js
+++ b/src/js/entities/types.js
@@ -53,6 +53,7 @@
  * @property {string=} text
  * @property {Keyword[]=} keywords
  * @property {Record<string, any>=} data
+ * @property {Card=} summonedBy
  */
 
 export {}; // purely for typedefs

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -193,14 +193,15 @@ export class EffectSystem {
 
   summonUnit(effect, context) {
     const { unit, count } = effect;
-    const { player } = context;
+    const { player, card } = context;
 
     for (let i = 0; i < count; i++) {
       const newUnit = new Card({
         name: unit.name,
         type: 'ally', // Summoned units are typically allies
         data: { attack: unit.attack, health: unit.health },
-        keywords: unit.keywords
+        keywords: unit.keywords,
+        summonedBy: card
       });
       player.battlefield.add(newUnit);
       console.log(`Summoned ${newUnit.name} to battlefield.`);

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -52,6 +52,7 @@ export function renderPlay(container, game, { onUpdate } = {}) {
 
   function showTooltip(card, event, game) {
     if (tooltipEl) hideTooltip(); // Hide any existing tooltip
+    const tooltipCard = card.summonedBy || card;
 
     tooltipEl = el('div', { class: 'card-tooltip' });
     tooltipEl.style.position = 'absolute';
@@ -73,7 +74,7 @@ export function renderPlay(container, game, { onUpdate } = {}) {
     }
 
     const img = new Image();
-    img.alt = card.name;
+    img.alt = tooltipCard.name;
     img.onload = () => {
       img.style.maxWidth = '100%';
       img.style.maxHeight = '100%';
@@ -81,14 +82,14 @@ export function renderPlay(container, game, { onUpdate } = {}) {
       position();
     };
     img.onerror = () => {
-      tooltipEl.textContent = card.text;
+      tooltipEl.textContent = tooltipCard.text;
       tooltipEl.style.backgroundColor = 'rgba(0,0,0,0.8)';
       tooltipEl.style.color = 'white';
       tooltipEl.style.padding = '5px';
       tooltipEl.style.borderRadius = '3px';
       position();
     };
-    img.src = `src/assets/cards/${card.id}.png`;
+    img.src = `src/assets/cards/${tooltipCard.id}.png`;
     position();
   }
 


### PR DESCRIPTION
## Summary
- track the source card when allies are summoned
- show the summoning card's art in ally tooltips
- test tooltip and origin tracking for summoned allies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c03635b04c8323a1e3b8563799f6d6