### PR TITLE
feat: auto-draw at turn start and remove draw button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Getting Started
 
 How To Play
 - Goal: Reduce the enemy hero’s health to 0 before yours reaches 0.
+- At the start of each turn, you automatically draw a card.
 - Your Turn — controls at the top of the page:
-  - Draw: Draw 1 card from your Library to your Hand.
   - Place Resource (first): Pitch the first card from your Hand to your Resources (limit 1 per turn). Resources determine how many costs you can pay this turn.
   - Resolve Combat: Resolves attacks you’ve declared from your Battlefield.
   - End Turn: Ends your turn and lets the AI take a turn. Your next turn starts and you auto-draw 1 card.

--- a/__tests__/game.cards.test.js
+++ b/__tests__/game.cards.test.js
@@ -7,17 +7,26 @@ test('setupMatch creates a 60 card library', async () => {
   expect(g.opponent.library.cards.length + g.opponent.hand.cards.length).toBe(60);
 });
 
-test('setupMatch assigns different heroes to players', async () => {
-  const g = new Game();
-  await g.setupMatch();
-  expect(g.player.hero).toBeDefined();
-  expect(g.opponent.hero).toBeDefined();
-  expect(g.player.hero.id).not.toBe(g.opponent.hero.id);
-});
+  test('setupMatch assigns different heroes to players', async () => {
+    const g = new Game();
+    await g.setupMatch();
+    expect(g.player.hero).toBeDefined();
+    expect(g.opponent.hero).toBeDefined();
+    expect(g.player.hero.id).not.toBe(g.opponent.hero.id);
+  });
 
-test('cards loaded with text for tooltips', async () => {
-  const g = new Game();
-  await g.setupMatch();
-  const hasText = g.allCards.every(c => typeof c.text === 'string');
-  expect(hasText).toBe(true);
-});
+  test('cards loaded with text for tooltips', async () => {
+    const g = new Game();
+    await g.setupMatch();
+    const hasText = g.allCards.every(c => typeof c.text === 'string');
+    expect(hasText).toBe(true);
+  });
+
+  test('players draw a card at the start of their turn', async () => {
+    const g = new Game();
+    await g.setupMatch();
+    expect(g.player.hand.size()).toBe(4);
+    const before = g.player.hand.size();
+    g.turns.startTurn();
+    expect(g.player.hand.size()).toBe(before + 1);
+  });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -35,6 +35,7 @@ export default class Game {
           this.effects.execute(player.hero.passive, { game: this, player, card: player.hero });
         }
       }
+      if (player) this.draw(player, 1);
     });
 
     // Players
@@ -116,11 +117,11 @@ export default class Game {
     
 
     this.turns.setActivePlayer(this.player);
-    this.turns.startTurn();
-    this.resources.startTurn(this.player);
     // Draw opening hand
     this.draw(this.player, 3);
     this.draw(this.opponent, 3);
+    this.turns.startTurn();
+    this.resources.startTurn(this.player);
   }
 
   draw(player, n = 1) {
@@ -315,7 +316,6 @@ export default class Game {
     this.turns.setActivePlayer(this.opponent);
     this.turns.startTurn();
     this.resources.startTurn(this.opponent);
-    this.draw(this.opponent, 1);
     const affordable = this.opponent.hand.cards.filter(c => this.canPlay(this.opponent, c)).sort((a,b)=> (a.cost||0)-(b.cost||0));
     if (affordable[0]) await this.playFromHand(this.opponent, affordable[0].id);
     for (const c of this.opponent.battlefield.cards) this.combat.declareAttacker(c);
@@ -333,7 +333,6 @@ export default class Game {
     this.turns.setActivePlayer(this.player);
     this.turns.startTurn();
     this.resources.startTurn(this.player);
-    this.draw(this.player, 1);
   }
 
   async reset() {

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -106,7 +106,6 @@ export function renderPlay(container, game, { onUpdate } = {}) {
   );
 
   const controls = el('div', { class: 'controls' },
-    el('button', { onclick: () => { game.draw(p, 1); onUpdate?.(); } }, 'Draw'),
     el('button', { onclick: () => { onUpdate?.(); } }, 'Refresh'),
     el('button', { onclick: () => { game.resolveCombat(p, e); onUpdate?.(); } }, 'Resolve Combat'),
     el('button', { onclick: async () => { await game.useHeroPower(p); onUpdate?.(); }, disabled: p.hero.powerUsed || game.resources.pool(p) < 2 }, 'Hero Power'),


### PR DESCRIPTION
## Summary
- draw one card automatically on each player's turn start
- drop manual Draw control from play UI
- document automatic draw and test turn-start draw

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c037c84bc88323869cc73862bb96f5