### PR TITLE
feat: resolve attacks instantly

### DIFF
--- a/__tests__/hero.attack.test.js
+++ b/__tests__/hero.attack.test.js
@@ -1,14 +1,30 @@
 import Game from '../src/js/game.js';
 import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
 
-test('hero can attack when toggled', () => {
+test('hero attacks instantly and only once per turn', async () => {
   const g = new Game();
   g.player.hero = new Hero({ name: 'Hero', data: { attack: 2, health: 10 } });
   g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
   g.player.battlefield.cards = [];
   g.opponent.battlefield.cards = [];
 
-  expect(g.toggleAttacker(g.player, g.player.hero.id)).toBe(true);
-  g.resolveCombat(g.player, g.opponent);
+  expect(await g.attack(g.player, g.player.hero.id)).toBe(true);
+  expect(g.opponent.hero.data.health).toBe(8);
+  expect(await g.attack(g.player, g.player.hero.id)).toBe(false);
   expect(g.opponent.hero.data.health).toBe(8);
 });
+
+test('hero can target enemy allies', async () => {
+  const g = new Game();
+  g.player.hero = new Hero({ name: 'Hero', data: { attack: 3, health: 10 } });
+  g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
+  const foe = new Card({ name: 'Foe', data: { attack: 1, health: 3 } });
+  g.opponent.battlefield.cards = [foe];
+  g.player.battlefield.cards = [];
+
+  await g.attack(g.player, g.player.hero.id, foe.id);
+  expect(foe.data.health).toBe(0);
+  expect(g.opponent.hero.data.health).toBe(10);
+});
+

--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -13,7 +13,7 @@ describe('UI Play', () => {
       player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
       opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
       resources: { pool: () => 0, available: () => 0 },
-      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true,
     };
 
     renderPlay(container, game);
@@ -56,7 +56,7 @@ describe('UI Play', () => {
       player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [card], size: () => 1 } },
       opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
       resources: { pool: () => 0, available: () => 0 },
-      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true,
     };
 
     renderPlay(container, game);
@@ -97,7 +97,7 @@ describe('UI Play', () => {
       player: { hero: playerHero, battlefield: { cards: [summoned] }, hand: { cards: [], size: () => 0 } },
       opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
       resources: { pool: () => 0, available: () => 0 },
-      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true,
     };
 
     renderPlay(container, game);
@@ -137,7 +137,7 @@ describe('UI Play', () => {
       player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [card], size: () => 1 } },
       opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
       resources: { pool: () => 0, available: () => 0 },
-      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true,
     };
 
     renderPlay(container, game);
@@ -182,7 +182,7 @@ describe('UI Play', () => {
       player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [card], size: () => 1 } },
       opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
       resources: { pool: () => 0, available: () => 0 },
-      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true,
     };
 
     renderPlay(container, game);
@@ -228,7 +228,7 @@ describe('UI Play', () => {
       player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [card1, card2], size: () => 2 } },
       opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
       resources: { pool: () => 0, available: () => 0 },
-      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true,
     };
 
     renderPlay(container, game);
@@ -255,7 +255,7 @@ describe('UI Play', () => {
       player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
       opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
       resources: { pool: () => 0, available: () => 0 },
-      draw: jest.fn(), resolveCombat: jest.fn(), endTurn: jest.fn(), toggleAttacker: jest.fn(), playFromHand: () => true,
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true,
     };
 
     renderPlay(container, game);

--- a/__tests__/whirlwind.spell-damage.test.js
+++ b/__tests__/whirlwind.spell-damage.test.js
@@ -9,6 +9,7 @@ test('Spell Damage +1 from Scarlet Sorcerer boosts Whirlwind', async () => {
   g.player.hand.cards = [];
   g.player.battlefield.cards = [];
   g.opponent.battlefield.cards = [];
+  g.opponent.hero.data.armor = 0;
   g.resources._pool.set(g.player, 10);
 
   // Add Scarlet Sorcerer to grant Spell Damage +1

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -107,14 +107,13 @@ export function renderPlay(container, game, { onUpdate } = {}) {
 
   const controls = el('div', { class: 'controls' },
     el('button', { onclick: () => { onUpdate?.(); } }, 'Refresh'),
-    el('button', { onclick: () => { game.resolveCombat(p, e); onUpdate?.(); } }, 'Resolve Combat'),
     el('button', { onclick: async () => { await game.useHeroPower(p); onUpdate?.(); }, disabled: p.hero.powerUsed || game.resources.pool(p) < 2 }, 'Hero Power'),
     el('button', { onclick: async () => { await game.endTurn(); onUpdate?.(); } }, 'End Turn')
   );
 
   const playerRow = el('div', { class: 'row player' },
     heroPane(p.hero),
-    el('div', { class: 'zone' }, zoneList('Player Battlefield', [p.hero, ...p.battlefield.cards], { clickCard: (c)=>{ game.toggleAttacker(p, c.id); onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
+    el('div', { class: 'zone' }, zoneList('Player Battlefield', [p.hero, ...p.battlefield.cards], { clickCard: async (c)=>{ await game.attack(p, c.id); onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
     el('div', { class: 'zone' }, zoneList('Player Hand', p.hand.cards, { clickCard: async (c)=>{ if (!await game.playFromHand(p, c.id)) { /* ignore */ } onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip }))
   );
   const enemyRow = el('div', { class: 'row enemy' },


### PR DESCRIPTION
## Summary
- allow players to attack directly and select targets when enemies have allies
- remove manual combat resolution from the UI
- add coverage for instant attacks and target selection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c03d4af9fc832389d2472823ded592