### PR TITLE
feat: display active quests on battlefield

### DIFF
--- a/__tests__/quests.trial.test.js
+++ b/__tests__/quests.trial.test.js
@@ -27,10 +27,11 @@ test('quest rewards trigger when requirements met', async () => {
   g.resources._pool.set(g.player, 20);
 
   await g.playFromHand(g.player, quest.id);
+  expect(g.player.battlefield.cards.some(c => c.id === quest.id)).toBe(true);
   await g.playFromHand(g.player, e1.id);
   await g.playFromHand(g.player, e2.id);
   await g.playFromHand(g.player, e3.id);
 
-  expect(g.player.quests.cards.length).toBe(0);
+  expect(g.player.battlefield.cards.some(c => c.id === quest.id)).toBe(false);
   expect(g.player.hand.cards.some(c => c.id === filler.id)).toBe(true);
 });

--- a/src/js/entities/player.js
+++ b/src/js/entities/player.js
@@ -21,7 +21,6 @@ export class Player {
     this.graveyard = new Zone('graveyard');
     this.battlefield = new Zone('battlefield');
     this.removed = new Zone('removed');
-    this.quests = new Zone('quests');
   }
 
   equip(item) {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -216,7 +216,7 @@ export default class Game {
       player.hand.moveTo(player.battlefield, cardId);
       if (card.type === 'equipment') player.hero.equipment.push(card);
     } else if (card.type === 'quest') {
-      player.hand.moveTo(player.quests, cardId);
+      player.hand.moveTo(player.battlefield, cardId);
       this.quests.addQuest(player, card);
     } else {
       player.hand.moveTo(player.graveyard, cardId);
@@ -334,7 +334,9 @@ export default class Game {
     this.resources.startTurn(this.opponent);
     const affordable = this.opponent.hand.cards.filter(c => this.canPlay(this.opponent, c)).sort((a,b)=> (a.cost||0)-(b.cost||0));
     if (affordable[0]) await this.playFromHand(this.opponent, affordable[0].id);
-    for (const c of this.opponent.battlefield.cards) this.combat.declareAttacker(c);
+    for (const c of this.opponent.battlefield.cards) {
+      if (c.type === 'ally' || c.type === 'equipment') this.combat.declareAttacker(c);
+    }
     this.combat.setDefenderHero(this.player.hero);
     this.combat.resolve();
     this.cleanupDeaths(this.player, this.opponent);

--- a/src/js/systems/quests.js
+++ b/src/js/systems/quests.js
@@ -27,7 +27,7 @@ export class QuestSystem {
     const idx = arr.indexOf(rec);
     if (idx !== -1) arr.splice(idx, 1);
     // move quest card to graveyard
-    player.quests.moveTo(player.graveyard, rec.card.id);
+    player.battlefield.moveTo(player.graveyard, rec.card.id);
     if (rec.card.reward?.length) {
       this.game.effects.execute(rec.card.reward, { game: this.game, player, card: rec.card });
     }


### PR DESCRIPTION
## Summary
- move quest cards to the battlefield when played
- remove unused quest zone and send completed quests to the graveyard
- prevent AI from attacking with quest cards

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c056f1bdcc83238f51e904c3d4c89a