### PR TITLE
feat: include damage source in logs

### DIFF
--- a/__tests__/systems.effects.test.js
+++ b/__tests__/systems.effects.test.js
@@ -60,6 +60,26 @@ describe('EffectSystem', () => {
     expect(player.hero.data.health).toBe(9);
   });
 
+  test('dealDamage logs source of damage', async () => {
+    const game = new Game();
+    const player = game.player;
+    const enemy = new Card({ type: 'ally', name: 'E', data: { attack: 0, health: 5 } });
+    game.opponent.battlefield.add(enemy);
+    game.promptTarget = async () => enemy;
+    const source = new Card({ type: 'spell', name: 'Fireball' });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await game.effects.dealDamage(
+      { target: 'character', amount: 3 },
+      { game, player, card: source }
+    );
+
+    expect(logSpy).toHaveBeenCalledWith(
+      `${enemy.name} took 3 damage from ${source.name}. Remaining health: ${enemy.data.health}`
+    );
+    logSpy.mockRestore();
+  });
+
   test('buff can increase armor', async () => {
     const game = new Game();
     const player = game.player;

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -177,12 +177,16 @@ export class EffectSystem {
       if (remaining <= 0) continue;
       if (t.data && t.data.health != null) {
         t.data.health -= remaining;
-        console.log(`${t.name} took ${remaining} damage. Remaining health: ${t.data.health}`);
+        console.log(
+          `${t.name} took ${remaining} damage from ${card?.name ?? 'an unknown source'}. Remaining health: ${t.data.health}`
+        );
         if (t.data.health > 0 && freeze) freezeTarget(t, freeze);
         if (t.data.health <= 0) t.data.dead = true;
       } else if (t.health != null) {
         t.health -= remaining;
-        console.log(`${t.name} took ${remaining} damage. Remaining health: ${t.health}`);
+        console.log(
+          `${t.name} took ${remaining} damage from ${card?.name ?? 'an unknown source'}. Remaining health: ${t.health}`
+        );
         if (t.health > 0 && freeze) freezeTarget(t, freeze);
       }
       game.bus.emit('damageDealt', { player, source: card, amount: remaining, target: t });


### PR DESCRIPTION
## Summary
- include damage source in damage logs
- test that damage logging includes source

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c067bf51e08323b21ae580b0606f1d