### PR TITLE
fix: restrict transform targets to allies

### DIFF
--- a/__tests__/savory-deviate-delight.transform.test.js
+++ b/__tests__/savory-deviate-delight.transform.test.js
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+const cards = JSON.parse(fs.readFileSync(new URL('../data/cards.json', import.meta.url)));
+const savory = cards.find(c => c.id === 'consumable-savory-deviate-delight');
+
+test('Savory Deviate Delight only transforms allies', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+
+  const ally = new Card({ name: 'Ally', type: 'ally', data: { attack: 1, health: 1 }, keywords: [] });
+  const equipment = new Card({ name: 'Sword', type: 'equipment', data: {}, keywords: [] });
+  const quest = new Card({ name: 'Quest', type: 'quest', data: {}, keywords: [] });
+  g.player.battlefield.add(ally);
+  g.player.battlefield.add(equipment);
+  g.player.battlefield.add(quest);
+
+  const card = new Card(savory);
+  g.player.hand.add(card);
+
+  await g.playFromHand(g.player, card.id);
+
+  const transformed = g.player.battlefield.cards.find(c => c.id === ally.id);
+  expect(transformed.name).toBe('Pirate');
+  expect(g.player.battlefield.cards.find(c => c.id === equipment.id).name).toBe('Sword');
+  expect(g.player.battlefield.cards.find(c => c.id === quest.id).name).toBe('Quest');
+  expect(g.player.hero.name).not.toBe('Pirate');
+});
+
+test('Savory Deviate Delight transforms summoned allies', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+
+  const summoner = new Card({ name: 'Summoner', type: 'spell', data: {}, keywords: [] });
+  const token = { id: 'token', name: 'Token', data: { attack: 1, health: 1 }, keywords: [], summonedBy: summoner };
+  const quest = new Card({ name: 'Quest', type: 'quest', data: {}, keywords: [] });
+  g.player.battlefield.add(token);
+  g.player.battlefield.add(quest);
+
+  const card = new Card(savory);
+  g.player.hand.add(card);
+
+  await g.playFromHand(g.player, card.id);
+
+  const transformed = g.player.battlefield.cards.find(c => c.id === token.id);
+  expect(transformed.name).toBe('Pirate');
+  expect(g.player.battlefield.cards.find(c => c.id === quest.id).name).toBe('Quest');
+});

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -280,11 +280,15 @@ export class EffectSystem {
     const { target, into, duration } = effect;
     const { game, player } = context;
 
-    // For now, transform a random player ally
-    if (player.battlefield.cards.length > 0) {
-      const allyToTransform = game.rng.pick(player.battlefield.cards);
+    let pool = player.battlefield.cards;
+    if (target === 'randomAlly') {
+      pool = pool.filter(c => c.type === 'ally' || c.summonedBy);
+    }
+
+    if (pool.length > 0) {
+      const allyToTransform = game.rng.pick(pool);
       const originalData = { ...allyToTransform.data };
-      const originalKeywords = [...allyToTransform.keywords];
+      const originalKeywords = [...(allyToTransform.keywords || [])];
       const originalName = allyToTransform.name; // Store original name
 
       allyToTransform.name = into.name;
@@ -305,7 +309,7 @@ export class EffectSystem {
       }
       console.log(`Transformed ${allyToTransform.name} into a ${into.name}.`);
     } else {
-      console.log('No player ally found to transform.');
+      console.log('No valid ally found to transform.');
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure transform effect only selects ally or summoned ally targets
- add tests for Savory Deviate Delight targeting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c06b3b2d048323b0e1cbfbfab4337a