### PR TITLE
test: ensure Malfurion power presents options

### DIFF
--- a/__tests__/malfurion.hero-power.test.js
+++ b/__tests__/malfurion.hero-power.test.js
@@ -1,9 +1,22 @@
 import fs from 'fs';
+import { jest } from '@jest/globals';
 import Game from '../src/js/game.js';
 import Hero from '../src/js/entities/hero.js';
 
 const cards = JSON.parse(fs.readFileSync(new URL('../data/cards.json', import.meta.url)));
 const malfData = cards.find(c => c.id === 'hero-malfurion-stormrage-archdruid');
+
+test("Malfurion's hero power offers a choice", async () => {
+  const g = new Game();
+  await g.setupMatch();
+  g.player.hero = new Hero(malfData);
+  g.turns.turn = 2;
+  g.resources.startTurn(g.player);
+  const spy = jest.fn(async () => 0);
+  g.promptOption = spy;
+  await g.useHeroPower(g.player);
+  expect(spy).toHaveBeenCalledWith(["+1 ATK this turn", "Gain 2 Armor"]);
+});
 
 test("Malfurion's hero power can grant attack", async () => {
   const g = new Game();


### PR DESCRIPTION
## Summary
- test that Malfurion's Shapeshift hero power prompts the player to choose between +1 attack or +2 armor

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c070360cec8323aaeee6e36e29325b