### PR TITLE
fix: log damage from combat attacks

### DIFF
--- a/__tests__/systems.combat.test.js
+++ b/__tests__/systems.combat.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import Card from '../src/js/entities/card.js';
 import CombatSystem from '../src/js/systems/combat.js';
 import Player from '../src/js/entities/player.js';
@@ -95,5 +96,18 @@ describe('CombatSystem', () => {
     c.setDefenderHero(def.hero);
     c.resolve();
     expect(atk.hero.equipment.length).toBe(0);
+  });
+
+  test('damage dealt in combat is logged with source', () => {
+    const a = new Card({ type: 'ally', name: 'A', data: { attack: 3, health: 2 } });
+    const b = new Card({ type: 'ally', name: 'B', data: { attack: 2, health: 3 } });
+    const c = new CombatSystem();
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    c.declareAttacker(a);
+    c.assignBlocker(a.id, b);
+    c.resolve();
+    expect(spy).toHaveBeenCalledWith('B took 3 damage from A. Remaining health: 0');
+    expect(spy).toHaveBeenCalledWith('A took 2 damage from B. Remaining health: 0');
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- log damage events during combat resolution
- track combat damage in a new test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c07232d1048323ad344cde57465204