### PR TITLE
fix: Whirlwild damages friendly units

### DIFF
--- a/__tests__/whirlwind.opponent.test.js
+++ b/__tests__/whirlwind.opponent.test.js
@@ -1,0 +1,36 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('Whirlwind damages both sides when cast by opponent', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  // clear zones for controlled scenario
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.hand.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.opponent, 10);
+
+  // friendly minion
+  const friendly = new Card({ name: 'Friendly', type: 'ally', data: { attack: 0, health: 3 }, keywords: [] });
+  g.player.battlefield.add(friendly);
+  // enemy minion
+  const enemy = new Card({ name: 'Enemy', type: 'ally', data: { attack: 0, health: 3 }, keywords: [] });
+  g.opponent.battlefield.add(enemy);
+
+  // add Whirlwind to opponent hand
+  const whirlwindData = g.allCards.find(c => c.id === 'spell-whirlwind');
+  const whirlwind = new Card(whirlwindData);
+  g.opponent.hand.add(whirlwind);
+
+  const initialPlayerHero = g.player.hero.data.health;
+  const initialOpponentHero = g.opponent.hero.data.health;
+
+  await g.playFromHand(g.opponent, whirlwind.id);
+
+  expect(friendly.data.health).toBe(2);
+  expect(enemy.data.health).toBe(2);
+  expect(g.player.hero.data.health).toBe(initialPlayerHero - 1);
+  expect(g.opponent.hero.data.health).toBe(initialOpponentHero - 1);
+});

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -77,6 +77,7 @@ export class EffectSystem {
   async dealDamage(effect, context) {
     const { target, amount, freeze, beastBonus } = effect;
     const { game, player, card } = context;
+    const opponent = player === game.player ? game.opponent : game.player;
       let dmgAmount = amount;
       if (beastBonus) {
         const hasBeast = player.battlefield.cards.some(c => c.keywords?.includes('Beast'));
@@ -92,8 +93,8 @@ export class EffectSystem {
     switch (target) {
       case 'any': {
         const candidates = [
-          game.opponent.hero,
-          ...game.opponent.battlefield.cards,
+          opponent.hero,
+          ...opponent.battlefield.cards,
           player.hero,
           ...player.battlefield.cards,
         ];
@@ -104,9 +105,9 @@ export class EffectSystem {
       case 'character': {
         const candidates = [
           player.hero,
-          game.opponent.hero,
+          opponent.hero,
           ...player.battlefield.cards,
-          ...game.opponent.battlefield.cards,
+          ...opponent.battlefield.cards,
         ];
         const chosen = await game.promptTarget(candidates);
         if (chosen) actualTargets.push(chosen);
@@ -114,8 +115,8 @@ export class EffectSystem {
       }
       case 'upToThreeTargets': {
         const candidates = [
-          game.opponent.hero,
-          ...game.opponent.battlefield.cards,
+          opponent.hero,
+          ...opponent.battlefield.cards,
           player.hero,
           ...player.battlefield.cards,
         ];
@@ -133,18 +134,18 @@ export class EffectSystem {
       }
       case 'allCharacters':
         actualTargets.push(player.hero);
-        actualTargets.push(game.opponent.hero);
+        actualTargets.push(opponent.hero);
         actualTargets.push(...player.battlefield.cards);
-        actualTargets.push(...game.opponent.battlefield.cards);
+        actualTargets.push(...opponent.battlefield.cards);
         break;
       case 'allEnemies':
-        actualTargets.push(game.opponent.hero);
-        actualTargets.push(...game.opponent.battlefield.cards);
+        actualTargets.push(opponent.hero);
+        actualTargets.push(...opponent.battlefield.cards);
         break;
       case 'minion': {
         const candidates = [
           ...player.battlefield.cards,
-          ...game.opponent.battlefield.cards,
+          ...opponent.battlefield.cards,
         ];
         const chosen = await game.promptTarget(candidates);
         if (chosen) actualTargets.push(chosen);
@@ -152,8 +153,8 @@ export class EffectSystem {
       }
       case 'enemyHeroOrMinionWithoutTaunt': {
         const candidates = [
-          game.opponent.hero,
-          ...game.opponent.battlefield.cards.filter(c => !c.keywords?.includes('Taunt')),
+          opponent.hero,
+          ...opponent.battlefield.cards.filter(c => !c.keywords?.includes('Taunt')),
         ];
         const chosen = await game.promptTarget(candidates);
         if (chosen) actualTargets.push(chosen);
@@ -193,7 +194,7 @@ export class EffectSystem {
     }
 
     await game.cleanupDeaths(player, player);
-    await game.cleanupDeaths(game.opponent, player);
+    await game.cleanupDeaths(opponent, player);
   }
 
   summonUnit(effect, context) {


### PR DESCRIPTION
## Summary
- ensure damage effects correctly determine the opposing player
- cover opponent casting Whirlwind to hit both sides

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c074dd0a84832384e26eee74204444