### PR TITLE
feat: show game over dialog with restart

### DIFF
--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -305,5 +305,40 @@ describe('UI Play', () => {
     const battlefieldList = container.querySelector('.row.player .zone-list');
     expect(battlefieldList.textContent).toContain('Player Hero');
   });
+
+  test('shows win dialog and restarts game', async () => {
+    const container = document.createElement('div');
+    const playerHero = new Hero({ name: 'Player', data: { health: 10 } });
+    const enemyHero = new Hero({ name: 'Enemy', data: { health: 0 } });
+    const reset = jest.fn().mockResolvedValue();
+    const game = {
+      player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      resources: { pool: () => 0, available: () => 0 },
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true, reset,
+    };
+    renderPlay(container, game, { onUpdate: jest.fn() });
+    const dialog = container.querySelector('.game-over');
+    expect(dialog.textContent).toContain('You win!');
+    const btn = dialog.querySelector('button');
+    btn.dispatchEvent(new Event('click'));
+    await Promise.resolve();
+    expect(reset).toHaveBeenCalled();
+  });
+
+  test('shows lose dialog when player hero health is zero', () => {
+    const container = document.createElement('div');
+    const playerHero = new Hero({ name: 'Player', data: { health: 0 } });
+    const enemyHero = new Hero({ name: 'Enemy', data: { health: 5 } });
+    const game = {
+      player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      resources: { pool: () => 0, available: () => 0 },
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true, reset: jest.fn(),
+    };
+    renderPlay(container, game);
+    const dialog = container.querySelector('.game-over');
+    expect(dialog.textContent).toContain('You lose!');
+  });
 });
 

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -126,5 +126,18 @@ export function renderPlay(container, game, { onUpdate } = {}) {
   );
 
   container.append(header, controls, enemyRow, playerRow);
+
+  const pDead = p.hero.data.health <= 0;
+  const eDead = e.hero.data.health <= 0;
+  if (pDead || eDead) {
+    const msg = pDead ? 'You lose!' : 'You win!';
+    const dialog = el('div', { class: 'game-over' },
+      el('div', {},
+        el('p', {}, msg),
+        el('button', { onclick: async () => { await game.reset(); onUpdate?.(); } }, 'Restart')
+      )
+    );
+    container.append(dialog);
+  }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -92,3 +92,27 @@ ul.zone-list li {
   margin-top: 0.5em;
   padding: 4px 6px;
 }
+
+.game-over {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.game-over > div {
+  background: #0b0f14;
+  border: 1px solid #203040;
+  padding: 1em;
+  text-align: center;
+}
+
+.game-over button {
+  margin-top: 0.5em;
+  padding: 4px 6px;
+}


### PR DESCRIPTION
## Summary
- show win/lose dialog when a hero hits 0 HP
- add restart button to reset game from dialog
- style game-over overlay and test win/lose behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c07720fdd483239304e410e1d2e36b