### PR TITLE
fix: auto-select AI targets

### DIFF
--- a/__tests__/ai.targeting.test.js
+++ b/__tests__/ai.targeting.test.js
@@ -1,0 +1,15 @@
+import Game from '../src/js/game.js';
+
+test('AI auto-selects a target without user interaction', async () => {
+  const g = new Game();
+  // Simulate AI's turn
+  g.turns.setActivePlayer(g.opponent);
+  // Pretend we are running in a browser environment
+  global.document = {};
+  // Deterministic RNG
+  g.rng.pick = (arr) => arr[0];
+  const candidates = [{ name: 'Foo' }, { name: 'Bar' }];
+  const target = await g.promptTarget(candidates);
+  expect(target).toBe(candidates[0]);
+  delete global.document;
+});

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -236,9 +236,16 @@ export default class Game {
 
   async promptTarget(candidates, { allowNoMore = false } = {}) {
     if (!candidates?.length) return null;
+
+    // If it's the AI's turn, auto-select a target without prompting
+    if (this.turns.activePlayer && this.turns.activePlayer !== this.player) {
+      return this.rng.pick(candidates);
+    }
+
     if (typeof document === 'undefined') {
       return candidates[0];
     }
+
     return new Promise((resolve) => {
       const overlay = document.createElement('div');
       overlay.className = 'target-prompt';


### PR DESCRIPTION
## Summary
- skip player target prompt when AI uses effects
- cover AI auto-targeting with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c07d73cc748323abca34c139496bd8