### PR TITLE
fix: prevent equipment from being targeted in ally attacks

### DIFF
--- a/__tests__/ally.attack-targeting.test.js
+++ b/__tests__/ally.attack-targeting.test.js
@@ -1,0 +1,23 @@
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+
+// Equipment should not be selectable as a target when attacking with an ally.
+test('equipment cannot be targeted by ally attacks', async () => {
+  const g = new Game();
+  g.player.hero = new Hero({ name: 'Hero', data: { health: 10 } });
+  g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
+
+  const ally = new Card({ name: 'Attacker', type: 'ally', data: { attack: 2, health: 2 } });
+  const equipment = new Card({ name: 'Sword', type: 'equipment', data: {} });
+
+  g.player.battlefield.cards = [ally];
+  g.opponent.battlefield.cards = [equipment];
+  g.opponent.hero.equipment.push(equipment);
+
+  const initial = g.opponent.hero.data.health;
+  await g.attack(g.player, ally.id, equipment.id);
+
+  expect(g.opponent.hero.data.health).toBe(initial - 2);
+  expect(g.opponent.battlefield.cards).toContain(equipment);
+});

--- a/__tests__/whirlwind.opponent.test.js
+++ b/__tests__/whirlwind.opponent.test.js
@@ -10,6 +10,8 @@ test('Whirlwind damages both sides when cast by opponent', async () => {
   g.player.battlefield.cards = [];
   g.opponent.hand.cards = [];
   g.opponent.battlefield.cards = [];
+  g.player.hero.data.armor = 0;
+  g.opponent.hero.data.armor = 0;
   g.resources._pool.set(g.opponent, 10);
 
   // friendly minion

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -311,7 +311,7 @@ export default class Game {
     const atk = typeof card.totalAttack === 'function' ? card.totalAttack() : (card.data?.attack ?? 0);
     if (atk < 1 || card.data?.attacked) return false;
     let target = null;
-    const candidates = [defender.hero, ...defender.battlefield.cards];
+    const candidates = [defender.hero, ...defender.battlefield.cards.filter(c => c.type !== 'equipment')];
     if (defender.battlefield.cards.length > 0) {
       if (targetId) {
         target = candidates.find(c => c.id === targetId) || null;


### PR DESCRIPTION
## Summary
- prevent equipment from appearing in potential targets when attacking
- add regression test for ally attacks targeting equipment
- normalize armor in Whirlwind test for determinism

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c08e8f880c8323b18641176ce7144c