### PR TITLE
fix: enforce summoning sickness unless ally has Rush

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -103,6 +103,7 @@ Unlike typical TCGs, WoW RPG TCG includes **persistent progression**:
 
 -   Represent summoned creatures, mercenaries, or lore characters.\
 -   Example: *Grunt of Orgrimmar -- 2 ATK, 2 HP, Taunt.*
+-   Cannot attack the turn they enter play unless they have the **Rush** keyword.
 
 ### Equipment Cards
 

--- a/__tests__/ally.summoning-sickness.test.js
+++ b/__tests__/ally.summoning-sickness.test.js
@@ -1,0 +1,52 @@
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+
+describe('summoning sickness and rush', () => {
+  test('played ally without Rush cannot attack immediately', async () => {
+    const g = new Game();
+    g.player.hero = new Hero({ name: 'Hero', data: { health: 10 } });
+    g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
+    const ally = new Card({ type: 'ally', name: 'Footman', cost: 0, data: { attack: 1, health: 1 }, keywords: [] });
+    g.player.hand.add(ally);
+    await g.playFromHand(g.player, ally.id);
+    expect(await g.attack(g.player, ally.id)).toBe(false);
+  });
+
+  test('played ally with Rush can attack immediately', async () => {
+    const g = new Game();
+    g.player.hero = new Hero({ name: 'Hero', data: { health: 10 } });
+    g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
+    const ally = new Card({ type: 'ally', name: 'Raider', cost: 0, data: { attack: 1, health: 1 }, keywords: ['Rush'] });
+    g.player.hand.add(ally);
+    await g.playFromHand(g.player, ally.id);
+    const initial = g.opponent.hero.data.health;
+    expect(await g.attack(g.player, ally.id)).toBe(true);
+    expect(g.opponent.hero.data.health).toBe(initial - 1);
+  });
+
+  test('summoned ally without Rush cannot attack immediately', async () => {
+    const g = new Game();
+    g.player.hero = new Hero({ name: 'Hero', data: { health: 10 } });
+    g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
+    const spell = new Card({ type: 'spell', name: 'Summon', cost: 0, effects: [{ type: 'summon', unit: { name: 'Token', attack: 1, health: 1, keywords: [] }, count: 1 }] });
+    g.player.hand.add(spell);
+    await g.playFromHand(g.player, spell.id);
+    const summoned = g.player.battlefield.cards.find(c => c.name === 'Token');
+    expect(await g.attack(g.player, summoned.id)).toBe(false);
+  });
+
+  test('summoned ally with Rush can attack immediately', async () => {
+    const g = new Game();
+    g.player.hero = new Hero({ name: 'Hero', data: { health: 10 } });
+    g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
+    const spell = new Card({ type: 'spell', name: 'Summon', cost: 0, effects: [{ type: 'summon', unit: { name: 'Rusher', attack: 1, health: 1, keywords: ['Rush'] }, count: 1 }] });
+    g.player.hand.add(spell);
+    await g.playFromHand(g.player, spell.id);
+    const summoned = g.player.battlefield.cards.find(c => c.name === 'Rusher');
+    const initial = g.opponent.hero.data.health;
+    expect(await g.attack(g.player, summoned.id)).toBe(true);
+    expect(g.opponent.hero.data.health).toBe(initial - 1);
+  });
+});
+

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -221,6 +221,10 @@ export default class Game {
     if (card.type === 'ally' || card.type === 'equipment') {
       player.hand.moveTo(player.battlefield, cardId);
       if (card.type === 'equipment') player.hero.equipment.push(card);
+      if (card.type === 'ally' && !card.keywords?.includes('Rush')) {
+        card.data = card.data || {};
+        card.data.attacked = true;
+      }
     } else if (card.type === 'quest') {
       player.hand.moveTo(player.battlefield, cardId);
       this.quests.addQuest(player, card);

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -209,6 +209,9 @@ export class EffectSystem {
         keywords: unit.keywords,
         summonedBy: card
       });
+      if (!newUnit.keywords?.includes('Rush')) {
+        newUnit.data.attacked = true;
+      }
       player.battlefield.add(newUnit);
       console.log(`Summoned ${newUnit.name} to battlefield.`);
     }


### PR DESCRIPTION
## Summary
- prevent played allies from attacking the turn they enter play unless they have Rush
- apply same summoning sickness to units created by summon effects
- document ally attack restriction and add regression tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c09414feac83238ff6efc609a5bcfd