### PR TITLE
feat: empower future demons

### DIFF
--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -217,6 +217,22 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         expect(g.player.graveyard.cards.some(c => c.id === consumable.id)).toBe(true);
         break;
       }
+      case 'summonBuff': {
+        await g.playFromHand(g.player, card.id);
+        const demon = new Card({
+          id: 'test-demon',
+          name: 'Test Demon',
+          type: 'ally',
+          cost: 0,
+          data: { attack: 1, health: 1 },
+          keywords: ['Demon'],
+        });
+        g.player.hand.add(demon);
+        await g.playFromHand(g.player, demon.id);
+        expect(demon.data.attack).toBe(2);
+        expect(demon.data.health).toBe(2);
+        break;
+      }
       default:
         throw new Error('Unhandled effect type: ' + effect.type);
     }

--- a/__tests__/demonheart-grimoire.summon-buff.test.js
+++ b/__tests__/demonheart-grimoire.summon-buff.test.js
@@ -1,0 +1,66 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('Demonheart Grimoire buffs demon allies summoned after it is played', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+
+  const earlyDemon = new Card({
+    id: 'ally-early-demon',
+    name: 'Early Demon',
+    type: 'ally',
+    cost: 0,
+    data: { attack: 1, health: 1 },
+    keywords: ['Demon']
+  });
+  g.player.hand.add(earlyDemon);
+  await g.playFromHand(g.player, earlyDemon.id);
+  expect(earlyDemon.data.attack).toBe(1);
+  expect(earlyDemon.data.health).toBe(1);
+
+  const grimoire = new Card({
+    id: 'equipment-demonheart-grimoire',
+    name: 'Demonheart Grimoire',
+    type: 'equipment',
+    cost: 0,
+    effects: [{ type: 'summonBuff', keyword: 'Demon', attack: 1, health: 1 }],
+  });
+  g.player.hand.add(grimoire);
+  await g.playFromHand(g.player, grimoire.id);
+
+  const laterDemon = new Card({
+    id: 'ally-later-demon',
+    name: 'Later Demon',
+    type: 'ally',
+    cost: 0,
+    data: { attack: 2, health: 2 },
+    keywords: ['Demon']
+  });
+  g.player.hand.add(laterDemon);
+  await g.playFromHand(g.player, laterDemon.id);
+  expect(laterDemon.data.attack).toBe(3);
+  expect(laterDemon.data.health).toBe(3);
+
+  const summoningSpell = new Card({
+    id: 'spell-summon-demon',
+    name: 'Summon Demon',
+    type: 'spell',
+    cost: 0,
+    effects: [{ type: 'summon', unit: { name: 'Demon Token', attack: 1, health: 1, keywords: ['Demon'] }, count: 1 }],
+  });
+  g.player.hand.add(summoningSpell);
+  await g.playFromHand(g.player, summoningSpell.id);
+  const token = g.player.battlefield.cards.find(c => c.name === 'Demon Token');
+  expect(token.data.attack).toBe(2);
+  expect(token.data.health).toBe(2);
+
+  // Early demon remains unbuffed
+  expect(earlyDemon.data.attack).toBe(1);
+  expect(earlyDemon.data.health).toBe(1);
+});
+

--- a/data/cards.json
+++ b/data/cards.json
@@ -1011,8 +1011,10 @@
     "cost": 3,
     "effects": [
       {
-        "type": "rawText",
-        "text": "Demons you summon gain +1/+1."
+        "type": "summonBuff",
+        "keyword": "Demon",
+        "attack": 1,
+        "health": 1
       }
     ],
     "keywords": [


### PR DESCRIPTION
## Summary
- grant +1/+1 to demon allies that enter after Demonheart Grimoire
- add summon buff handler and summon event for equipment auras
- verify Demonheart Grimoire buffs only later demons and cover new effect in tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c10ab8125c8323983295476c670bc5