### PR TITLE
feat: freeze combat targets

### DIFF
--- a/__tests__/arcanists-signet.spell-damage.test.js
+++ b/__tests__/arcanists-signet.spell-damage.test.js
@@ -8,6 +8,7 @@ test("Arcanist's Signet grants +1 Spell Damage to the first spell each turn", as
   g.player.hand.cards = [];
   g.player.battlefield.cards = [];
   g.opponent.battlefield.cards = [];
+  g.opponent.hero.data.armor = 0;
   g.resources._pool.set(g.player, 10);
   const signet = new Card({
     id: 'equipment-arcanist-s-signet',

--- a/__tests__/systems.combat.test.js
+++ b/__tests__/systems.combat.test.js
@@ -98,6 +98,18 @@ describe('CombatSystem', () => {
     expect(atk.hero.equipment.length).toBe(0);
   });
 
+  test('freeze keyword freezes surviving targets in combat', () => {
+    const we = new Card({ type: 'ally', name: 'WE', data: { attack: 3, health: 6 }, keywords: ['Freeze'] });
+    const def = new Player({ name: 'Def' });
+    def.hero.data.health = 10;
+    const c = new CombatSystem();
+    c.declareAttacker(we);
+    c.setDefenderHero(def.hero);
+    c.resolve();
+    expect(def.hero.data.health).toBe(7);
+    expect(def.hero.data.freezeTurns).toBe(1);
+  });
+
   test('damage dealt in combat is logged with source', () => {
     const a = new Card({ type: 'ally', name: 'A', data: { attack: 3, health: 2 } });
     const b = new Card({ type: 'ally', name: 'B', data: { attack: 2, health: 3 } });

--- a/src/js/systems/combat.js
+++ b/src/js/systems/combat.js
@@ -1,3 +1,5 @@
+import { freezeTarget } from './keywords.js';
+
 function getStat(card, key, def = 0) {
   if (key === 'attack' && typeof card?.totalAttack === 'function') return card.totalAttack();
   return (card?.data && typeof card.data[key] === 'number') ? card.data[key] : def;
@@ -89,9 +91,11 @@ export class CombatSystem {
     for (const { target, amount, source } of events) {
       let rem = armorApply(target, amount);
       const hp = getStat(target, 'health', 0);
-      setStat(target, 'health', Math.max(0, hp - rem));
+      const newHp = Math.max(0, hp - rem);
+      setStat(target, 'health', newHp);
       console.log(`${target.name} took ${rem} damage from ${source?.name ?? 'an unknown source'}. Remaining health: ${getStat(target, 'health', 0)}`);
-      if (getStat(target, 'health', 0) <= 0) setStat(target, 'dead', true);
+      if (source?.keywords?.includes?.('Freeze') && newHp > 0) freezeTarget(target, 1);
+      if (newHp <= 0) setStat(target, 'dead', true);
     }
 
     this.clear();


### PR DESCRIPTION
## Summary
- freeze surviving targets damaged by units with the Freeze keyword
- verify Water Elemental Guardian freezes targets after attacking
- stabilize Arcanist's Signet test by clearing opponent armor

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c10f3fe968832382bbdc42977a17f8