### PR TITLE
feat: display card data in tooltips with art

### DIFF
--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -31,7 +31,7 @@ describe('UI Play', () => {
     expect(enemyPane.textContent).toContain('Enemy ability');
   });
 
-  test('shows card image tooltip when art is available', () => {
+  test('shows card tooltip with art, name, and text when art is available', () => {
     const OriginalImage = global.Image;
     global.Image = class {
       constructor() {
@@ -64,9 +64,12 @@ describe('UI Play', () => {
     const li = container.querySelector(`[data-card-id="${card.id}"]`);
     li.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true, clientX: 0, clientY: 0 }));
 
-    const tooltipImg = container.querySelector('.card-tooltip img');
+    const tooltip = container.querySelector('.card-tooltip');
+    const tooltipImg = tooltip.querySelector('img');
     expect(tooltipImg).toBeTruthy();
-    expect(tooltipImg.getAttribute('src')).toBe(`src/assets/cards/${card.id}.png`);
+    expect(tooltipImg.getAttribute('src')).toBe(`src/assets/art/${card.id}-art.png`);
+    expect(tooltip.textContent).toContain(card.name);
+    expect(tooltip.textContent).toContain(card.text);
 
     global.Image = OriginalImage;
   });
@@ -105,9 +108,12 @@ describe('UI Play', () => {
     const li = container.querySelector(`[data-card-id="${summoned.id}"]`);
     li.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true, clientX: 0, clientY: 0 }));
 
-    const tooltipImg = container.querySelector('.card-tooltip img');
+    const tooltip = container.querySelector('.card-tooltip');
+    const tooltipImg = tooltip.querySelector('img');
     expect(tooltipImg).toBeTruthy();
-    expect(tooltipImg.getAttribute('src')).toBe(`src/assets/cards/${summoner.id}.png`);
+    expect(tooltipImg.getAttribute('src')).toBe(`src/assets/art/${summoner.id}-art.png`);
+    expect(tooltip.textContent).toContain(summoner.name);
+    expect(tooltip.textContent).toContain(summoner.text);
 
     global.Image = OriginalImage;
   });
@@ -146,7 +152,8 @@ describe('UI Play', () => {
     li.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true, clientX: 0, clientY: 0 }));
 
     const tooltip = container.querySelector('.card-tooltip');
-    expect(tooltip.textContent).toBe(card.text);
+    expect(tooltip.textContent).toContain(card.name);
+    expect(tooltip.textContent).toContain(card.text);
     expect(tooltip.querySelector('img')).toBeNull();
 
     global.Image = OriginalImage;
@@ -240,8 +247,10 @@ describe('UI Play', () => {
 
     const tooltips = container.querySelectorAll('.card-tooltip');
     expect(tooltips).toHaveLength(1);
-    const tooltipImg = tooltips[0].querySelector('img');
-    expect(tooltipImg.getAttribute('src')).toBe(`src/assets/cards/${card2.id}.png`);
+    const tooltip = tooltips[0];
+    const tooltipImg = tooltip.querySelector('img');
+    expect(tooltipImg.getAttribute('src')).toBe(`src/assets/art/${card2.id}-art.png`);
+    expect(tooltip.textContent).toContain(card2.name);
 
     global.Image = OriginalImage;
   });

--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -48,7 +48,13 @@ describe('UI Play', () => {
     };
 
     const container = document.createElement('div');
-    const card = { id: 'hero-jaina-proudmoore-archmage', name: 'Jaina', text: 'Archmage' };
+    const card = {
+      id: 'ally-scarlet-sorcerer',
+      name: 'Scarlet Sorcerer',
+      text: 'Spell Damage +1.',
+      cost: 3,
+      data: { attack: 3, health: 3 }
+    };
     const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
     const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 } });
 
@@ -70,6 +76,9 @@ describe('UI Play', () => {
     expect(tooltipImg.getAttribute('src')).toBe(`src/assets/art/${card.id}-art.png`);
     expect(tooltip.textContent).toContain(card.name);
     expect(tooltip.textContent).toContain(card.text);
+    expect(tooltip.querySelector('.stat.cost').textContent).toBe(String(card.cost));
+    expect(tooltip.querySelector('.stat.attack').textContent).toBe(String(card.data.attack));
+    expect(tooltip.querySelector('.stat.health').textContent).toBe(String(card.data.health));
 
     global.Image = OriginalImage;
   });

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -60,13 +60,6 @@ export function renderPlay(container, game, { onUpdate } = {}) {
     currentTooltip.style.zIndex = '1000';
     currentTooltip.style.maxWidth = `${window.innerWidth - 20}px`;
     currentTooltip.style.maxHeight = `${window.innerHeight - 20}px`;
-    currentTooltip.style.backgroundColor = 'rgba(0,0,0,0.8)';
-    currentTooltip.style.color = 'white';
-    currentTooltip.style.padding = '5px';
-    currentTooltip.style.borderRadius = '3px';
-    currentTooltip.style.display = 'flex';
-    currentTooltip.style.flexDirection = 'column';
-    currentTooltip.style.alignItems = 'center';
     container.append(currentTooltip);
 
     function position() {
@@ -83,23 +76,24 @@ export function renderPlay(container, game, { onUpdate } = {}) {
 
     const img = new Image();
     img.alt = tooltipCard.name;
+    img.style.maxWidth = '100%';
+    img.style.maxHeight = '100%';
+
+    const imgWrapper = el('div', { class: 'card-image-wrapper' }, img);
+    if (tooltipCard.cost != null) imgWrapper.append(el('div', { class: 'stat cost' }, tooltipCard.cost));
+    if (tooltipCard.data?.attack != null) imgWrapper.append(el('div', { class: 'stat attack' }, tooltipCard.data.attack));
+    if (tooltipCard.data?.health != null) imgWrapper.append(el('div', { class: 'stat health' }, tooltipCard.data.health));
+
     const info = el('div', { class: 'card-info' },
       el('h4', {}, tooltipCard.name),
       el('p', {}, tooltipCard.text)
     );
-    img.onload = () => {
-      if (tooltipEl !== currentTooltip) return;
-      img.style.maxWidth = '100%';
-      img.style.maxHeight = '100%';
-      currentTooltip.append(img, info);
-      position();
-    };
-    img.onerror = () => {
-      if (tooltipEl !== currentTooltip) return;
-      currentTooltip.append(info);
-      position();
-    };
+
+    img.onload = () => { if (tooltipEl === currentTooltip) position(); };
+    img.onerror = () => { if (tooltipEl === currentTooltip) { img.remove(); position(); } };
+
     img.src = `src/assets/art/${tooltipCard.id}-art.png`;
+    currentTooltip.append(imgWrapper, info);
     position();
   }
 

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -60,6 +60,13 @@ export function renderPlay(container, game, { onUpdate } = {}) {
     currentTooltip.style.zIndex = '1000';
     currentTooltip.style.maxWidth = `${window.innerWidth - 20}px`;
     currentTooltip.style.maxHeight = `${window.innerHeight - 20}px`;
+    currentTooltip.style.backgroundColor = 'rgba(0,0,0,0.8)';
+    currentTooltip.style.color = 'white';
+    currentTooltip.style.padding = '5px';
+    currentTooltip.style.borderRadius = '3px';
+    currentTooltip.style.display = 'flex';
+    currentTooltip.style.flexDirection = 'column';
+    currentTooltip.style.alignItems = 'center';
     container.append(currentTooltip);
 
     function position() {
@@ -76,23 +83,23 @@ export function renderPlay(container, game, { onUpdate } = {}) {
 
     const img = new Image();
     img.alt = tooltipCard.name;
+    const info = el('div', { class: 'card-info' },
+      el('h4', {}, tooltipCard.name),
+      el('p', {}, tooltipCard.text)
+    );
     img.onload = () => {
       if (tooltipEl !== currentTooltip) return;
       img.style.maxWidth = '100%';
       img.style.maxHeight = '100%';
-      currentTooltip.append(img);
+      currentTooltip.append(img, info);
       position();
     };
     img.onerror = () => {
       if (tooltipEl !== currentTooltip) return;
-      currentTooltip.textContent = tooltipCard.text;
-      currentTooltip.style.backgroundColor = 'rgba(0,0,0,0.8)';
-      currentTooltip.style.color = 'white';
-      currentTooltip.style.padding = '5px';
-      currentTooltip.style.borderRadius = '3px';
+      currentTooltip.append(info);
       position();
     };
-    img.src = `src/assets/cards/${tooltipCard.id}.png`;
+    img.src = `src/assets/art/${tooltipCard.id}-art.png`;
     position();
   }
 

--- a/styles.css
+++ b/styles.css
@@ -140,3 +140,66 @@ ul.zone-list li {
   margin-top: 0.5em;
   padding: 4px 6px;
 }
+
+/* Card tooltip styling */
+.card-tooltip {
+  background: #102029;
+  border: 2px solid #0e5957;
+  border-radius: 8px;
+  color: #e5eef8;
+  font-size: 14px;
+  overflow: hidden;
+  width: 220px;
+}
+
+.card-image-wrapper {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1280 / 896;
+  overflow: hidden;
+  background: #000;
+}
+
+.card-image-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.card-tooltip .stat {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  color: #fff;
+}
+
+.card-tooltip .stat.cost {
+  top: 4px;
+  right: 4px;
+  background: #1e90ff;
+}
+
+.card-tooltip .stat.attack {
+  bottom: 4px;
+  left: 4px;
+  background: #f0b429;
+}
+
+.card-tooltip .stat.health {
+  bottom: 4px;
+  right: 4px;
+  background: #e74c3c;
+}
+
+.card-tooltip h4 {
+  margin: 4px 8px;
+}
+
+.card-tooltip p {
+  margin: 0 8px 8px;
+}


### PR DESCRIPTION
## Summary
- build card tooltips using card metadata and high-res art
- adjust tooltip image path and styling to scale art with aspect ratio
- update UI play tests for new tooltip structure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1bdd522f08323b2abf5839a170acd