### PR TITLE
feat: display card type and keywords

### DIFF
--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -53,6 +53,8 @@ describe('UI Play', () => {
       name: 'Scarlet Sorcerer',
       text: 'Spell Damage +1.',
       cost: 3,
+      type: 'ally',
+      keywords: ['Mage', 'Fire'],
       data: { attack: 3, health: 3 }
     };
     const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
@@ -79,6 +81,8 @@ describe('UI Play', () => {
     expect(tooltip.querySelector('.stat.cost').textContent).toBe(String(card.cost));
     expect(tooltip.querySelector('.stat.attack').textContent).toBe(String(card.data.attack));
     expect(tooltip.querySelector('.stat.health').textContent).toBe(String(card.data.health));
+    expect(tooltip.querySelector('.card-type').textContent).toBe(card.type);
+    expect(tooltip.querySelector('.card-keywords').textContent).toBe(card.keywords.join(', '));
 
     global.Image = OriginalImage;
   });
@@ -148,8 +152,8 @@ describe('UI Play', () => {
     };
 
     const container = document.createElement('div');
-    const summoner = { id: 'spell-summon-infernal', name: 'Summon Infernal', text: 'Summon a 6/6 Infernal.' };
-    const summoned = { id: 'token-infernal', name: 'Infernal', summonedBy: summoner };
+    const summoner = { id: 'spell-summon-infernal', name: 'Summon Infernal', text: 'Summon a 6/6 Infernal.', type: 'spell' };
+    const summoned = { id: 'token-infernal', name: 'Infernal', type: 'ally', summonedBy: summoner };
     const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
     const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 } });
 
@@ -192,7 +196,7 @@ describe('UI Play', () => {
     };
 
     const container = document.createElement('div');
-    const card = { id: 'hero-thrall-warchief-of-the-horde', name: 'Thrall', text: 'Warchief' };
+    const card = { id: 'hero-thrall-warchief-of-the-horde', name: 'Thrall', text: 'Warchief', type: 'hero' };
     const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
     const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 } });
 
@@ -238,7 +242,7 @@ describe('UI Play', () => {
     Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: 200 });
 
     const container = document.createElement('div');
-    const card = { id: 'hero-jaina-proudmoore-archmage', name: 'Jaina', text: 'Archmage' };
+    const card = { id: 'hero-jaina-proudmoore-archmage', name: 'Jaina', text: 'Archmage', type: 'hero' };
     const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
     const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 } });
 
@@ -283,8 +287,8 @@ describe('UI Play', () => {
     };
 
     const container = document.createElement('div');
-    const card1 = { id: 'hero-jaina-proudmoore-archmage', name: 'Jaina', text: 'Archmage' };
-    const card2 = { id: 'hero-thrall-warchief-of-the-horde', name: 'Thrall', text: 'Warchief' };
+    const card1 = { id: 'hero-jaina-proudmoore-archmage', name: 'Jaina', text: 'Archmage', type: 'hero' };
+    const card2 = { id: 'hero-thrall-warchief-of-the-horde', name: 'Thrall', text: 'Warchief', type: 'hero' };
     const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
     const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 } });
 
@@ -330,7 +334,7 @@ describe('UI Play', () => {
     };
 
     const container = document.createElement('div');
-    const card = { id: 'hero-jaina-proudmoore-archmage', name: 'Jaina', text: 'Archmage' };
+    const card = { id: 'hero-jaina-proudmoore-archmage', name: 'Jaina', text: 'Archmage', type: 'hero' };
     const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
     const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 } });
 

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -98,10 +98,15 @@ export function renderPlay(container, game, { onUpdate } = {}) {
     if (tooltipCard.data?.attack != null) imgWrapper.append(el('div', { class: 'stat attack' }, tooltipCard.data.attack));
     if (tooltipCard.data?.health != null) imgWrapper.append(el('div', { class: 'stat health' }, tooltipCard.data.health));
 
-    const info = el('div', { class: 'card-info' },
+    const infoChildren = [
+      el('div', { class: 'card-type' }, tooltipCard.type),
       el('h4', {}, tooltipCard.name),
-      el('p', {}, tooltipCard.text)
-    );
+      el('p', { class: 'card-text' }, tooltipCard.text)
+    ];
+    if (tooltipCard.keywords?.length) {
+      infoChildren.push(el('p', { class: 'card-keywords' }, tooltipCard.keywords.join(', ')));
+    }
+    const info = el('div', { class: 'card-info' }, ...infoChildren);
 
     img.onload = () => { if (tooltipEl === currentTooltip) position(); };
     img.onerror = () => { if (tooltipEl === currentTooltip) { img.remove(); position(); } };

--- a/styles.css
+++ b/styles.css
@@ -142,6 +142,7 @@ ul.zone-list li {
 }
 
 /* Card tooltip styling */
+
 .card-tooltip {
   background: #102029;
   border: 2px solid #0e5957;
@@ -150,6 +151,9 @@ ul.zone-list li {
   font-size: 14px;
   overflow: hidden;
   width: 220px;
+  height: 360px;
+  display: flex;
+  flex-direction: column;
 }
 
 .card-image-wrapper {
@@ -158,6 +162,7 @@ ul.zone-list li {
   aspect-ratio: 1280 / 896;
   overflow: hidden;
   background: #000;
+  flex: 0 0 auto;
 }
 
 .card-image-wrapper img {
@@ -197,10 +202,28 @@ ul.zone-list li {
   background: #e74c3c;
 }
 
-.card-tooltip h4 {
+.card-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-type {
+  margin: 4px 8px 0;
+  font-size: 12px;
+  text-transform: capitalize;
+}
+
+.card-info h4 {
   margin: 4px 8px;
 }
 
-.card-tooltip p {
+.card-text {
+  flex: 1;
+  margin: 0 8px;
+}
+
+.card-keywords {
   margin: 0 8px 8px;
+  font-style: italic;
 }


### PR DESCRIPTION
## Summary
- show card type and keywords in card tooltips
- standardize tooltip card height and expand text area
- test tooltip content for type and keywords

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c261c83b04832398ba4aa69258a5c6