### PR TITLE
fix: delay Northshire Acolyte draw until healing

### DIFF
--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -233,6 +233,13 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         expect(demon.data.health).toBe(2);
         break;
       }
+      case 'drawOnHeal': {
+        await g.playFromHand(g.player, card.id);
+        const handBefore = g.player.hand.cards.length;
+        await g.effects.healCharacter({ target: 'hero', amount: 1 }, { game: g, player: g.player, card: null });
+        expect(g.player.hand.cards.length).toBe(handBefore + effect.count);
+        break;
+      }
       default:
         throw new Error('Unhandled effect type: ' + effect.type);
     }

--- a/__tests__/northshire-acolyte.heal-draw.test.js
+++ b/__tests__/northshire-acolyte.heal-draw.test.js
@@ -1,0 +1,26 @@
+import Game from '../src/js/game.js';
+
+describe('Northshire Acolyte', () => {
+  test('draws when a friendly character is healed', async () => {
+    const g = new Game();
+    await g.setupMatch();
+    g.resources._pool.set(g.player, 10);
+    const initialHand = g.player.hand.cards.length;
+    g.addCardToHand('ally-northshire-acolyte');
+    await g.playFromHand(g.player, 'ally-northshire-acolyte');
+    expect(g.player.hand.cards.length).toBe(initialHand);
+
+    await g.effects.healCharacter({ target: 'hero', amount: 1 }, { game: g, player: g.player, card: null });
+    expect(g.player.hand.cards.length).toBe(initialHand + 1);
+
+    await g.effects.healCharacter({ target: 'hero', amount: 1 }, { game: g, player: g.player, card: null });
+    expect(g.player.hand.cards.length).toBe(initialHand + 1);
+
+    g.turns.setActivePlayer(g.player);
+    g.turns.startTurn();
+    g.resources.startTurn(g.player);
+    const handBeforeHeal = g.player.hand.cards.length;
+    await g.effects.healCharacter({ target: 'hero', amount: 1 }, { game: g, player: g.player, card: null });
+    expect(g.player.hand.cards.length).toBe(handBeforeHeal + 1);
+  });
+});

--- a/data/cards.json
+++ b/data/cards.json
@@ -670,7 +670,7 @@
     "cost": 2,
     "effects": [
       {
-        "type": "draw",
+        "type": "drawOnHeal",
         "count": 1
       }
     ],


### PR DESCRIPTION
## Summary
- trigger Northshire Acolyte card draw only when a friendly character is healed
- emit `characterHealed` events and handle `drawOnHeal` effect
- add regression tests for the acolyte heal-trigger

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2905b0ffc832386d3283d1e30bd38