### PR TITLE
feat: enforce taunt during targeting

### DIFF
--- a/__tests__/systems.targeting.test.js
+++ b/__tests__/systems.targeting.test.js
@@ -1,5 +1,6 @@
 import { isTargetLegal, selectTargets } from '../src/js/systems/targeting.js';
 import Card from '../src/js/entities/card.js';
+import Hero from '../src/js/entities/hero.js';
 
 describe('Targeting', () => {
   test('legality checks by type and name', () => {
@@ -9,6 +10,20 @@ describe('Targeting', () => {
     expect(isTargetLegal(s, { type: 'ally' })).toBe(false); // illegal action
     const list = selectTargets([a, s], { type: 'ally' });
     expect(list).toEqual([a]);
+  });
+
+  test('taunt allies must be targeted before hero or non-taunt allies', () => {
+    const hero = new Hero({ name: 'Hero' });
+    const taunt = new Card({ type: 'ally', name: 'T', keywords: ['Taunt'] });
+    const ally = new Card({ type: 'ally', name: 'A' });
+    const list = selectTargets([hero, ally, taunt]);
+    expect(list).toEqual([taunt]);
+  });
+
+  test('stealth allies are untargetable unless allowed', () => {
+    const stealth = new Card({ type: 'ally', name: 'S', keywords: ['Stealth'] });
+    expect(selectTargets([stealth])).toEqual([]);
+    expect(selectTargets([stealth], {}, { allowStealthTargeting: true })).toEqual([stealth]);
   });
 });
 

--- a/src/js/systems/targeting.js
+++ b/src/js/systems/targeting.js
@@ -1,5 +1,7 @@
 /** Simple targeting helpers. */
 
+import { enforceTaunt, isTargetable } from './keywords.js';
+
 export function isTargetLegal(target, criteria = {}) {
   if (!target) return false;
   if (target.type === 'quest') return false;
@@ -8,7 +10,10 @@ export function isTargetLegal(target, criteria = {}) {
   return true;
 }
 
-export function selectTargets(candidates, criteria = {}) {
-  return candidates.filter((t) => isTargetLegal(t, criteria));
+export function selectTargets(candidates, criteria = {}, options = {}) {
+  const legal = candidates
+    .filter((t) => isTargetLegal(t, criteria))
+    .filter((t) => isTargetable(t, options));
+  return enforceTaunt(legal);
 }
 


### PR DESCRIPTION
## Summary
- enforce Taunt and Stealth rules during target selection
- test targeting against Taunt and Stealth keywords

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c297fa9f8c83238b088e2abb8d2493