### PR TITLE
fix: make AI heal its own hero

### DIFF
--- a/__tests__/ai.healing-potion.test.js
+++ b/__tests__/ai.healing-potion.test.js
@@ -1,0 +1,34 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('AI heals its own hero with Healing Potion', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  // clear zones
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.hand.cards = [];
+  g.opponent.battlefield.cards = [];
+
+  // ensure opponent hero is damaged and has resources
+  g.resources._pool.set(g.opponent, 10);
+  g.opponent.hero.data.maxHealth = 30;
+  g.opponent.hero.data.health = 20;
+  const initialPlayerHealth = g.player.hero.data.health;
+
+  // add Healing Potion to opponent hand
+  const potionData = g.allCards.find(c => c.id === 'consumable-healing-potion');
+  const potion = new Card(potionData);
+  g.opponent.hand.add(potion);
+
+  // it's the AI's turn
+  g.turns.setActivePlayer(g.opponent);
+  // force RNG to pick the player's hero if promptTarget were used
+  g.rng.pick = (arr) => arr[1];
+
+  await g.playFromHand(g.opponent, potion.id);
+
+  expect(g.opponent.hero.data.health).toBe(25);
+  expect(g.player.hero.data.health).toBe(initialPlayerHealth);
+});

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -263,6 +263,13 @@ export class EffectSystem {
     switch (target) {
       case 'character': {
         const friendly = [player.hero, ...player.battlefield.cards.filter(c => c.type !== 'quest')];
+
+        // If it's the AI's turn, default to healing its own hero
+        if (game.turns.activePlayer && game.turns.activePlayer !== game.player) {
+          actualTargets.push(player.hero);
+          break;
+        }
+
         const enemy = selectTargets([
           opponent.hero,
           ...opponent.battlefield.cards.filter(c => c.type !== 'quest')


### PR DESCRIPTION
## Summary
- ensure AI targets its own hero when using Healing Potion
- add regression test for AI Healing Potion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2aa289edc8323b5be4d8a97c6f69f