### PR TITLE
feat: enforce taunt during attacks

### DIFF
--- a/__tests__/ai.taunt.test.js
+++ b/__tests__/ai.taunt.test.js
@@ -1,0 +1,20 @@
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+
+test('AI attacks taunt ally instead of hero', async () => {
+  const g = new Game();
+  g.player.hero = new Hero({ name: 'Hero', data: { health: 10 } });
+  g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
+
+  const defender = new Card({ name: 'Orgrimmar Grunt', type: 'ally', data: { attack: 2, health: 2 }, keywords: ['Taunt'] });
+  const attacker = new Card({ name: 'Attacker', type: 'ally', data: { attack: 3, health: 3 } });
+
+  g.player.battlefield.cards = [defender];
+  g.opponent.battlefield.cards = [attacker];
+
+  await g.endTurn();
+
+  expect(g.player.hero.data.health).toBe(10);
+  expect(g.player.graveyard.cards).toContain(defender);
+});

--- a/__tests__/ally.attack-targeting.test.js
+++ b/__tests__/ally.attack-targeting.test.js
@@ -40,3 +40,22 @@ test('quest cannot be targeted by ally attacks', async () => {
   expect(g.opponent.hero.data.health).toBe(initial - 2);
   expect(g.opponent.battlefield.cards).toContain(quest);
 });
+
+// Taunt allies must be attacked before the enemy hero.
+test('taunt forces attacks to target taunt ally', async () => {
+  const g = new Game();
+  g.player.hero = new Hero({ name: 'Hero', data: { health: 10 } });
+  g.opponent.hero = new Hero({ name: 'Enemy', data: { health: 10 } });
+
+  const attacker = new Card({ name: 'Attacker', type: 'ally', data: { attack: 2, health: 2 } });
+  const taunt = new Card({ name: 'Orgrimmar Grunt', type: 'ally', data: { attack: 2, health: 2 }, keywords: ['Taunt'] });
+
+  g.player.battlefield.cards = [attacker];
+  g.opponent.battlefield.cards = [taunt];
+
+  const initial = g.opponent.hero.data.health;
+  await g.attack(g.player, attacker.id, g.opponent.hero.id);
+
+  expect(g.opponent.hero.data.health).toBe(initial);
+  expect(g.opponent.graveyard.cards).toContain(taunt);
+});


### PR DESCRIPTION
## Summary
- enforce Taunt when selecting attack targets
- make AI attacks honor Taunt
- test Taunt in player and AI combat flows

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2aee4eeb88323ae053bbcf67708e3