### PR TITLE
fix: show stats for summoned allies

### DIFF
--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -153,7 +153,7 @@ describe('UI Play', () => {
 
     const container = document.createElement('div');
     const summoner = { id: 'spell-summon-infernal', name: 'Summon Infernal', text: 'Summon a 6/6 Infernal.', type: 'spell' };
-    const summoned = { id: 'token-infernal', name: 'Infernal', type: 'ally', summonedBy: summoner };
+    const summoned = { id: 'token-infernal', name: 'Infernal', type: 'ally', data: { attack: 6, health: 6 }, summonedBy: summoner };
     const playerHero = new Hero({ name: 'Player Hero', data: { health: 25 } });
     const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20 } });
 
@@ -175,6 +175,8 @@ describe('UI Play', () => {
     expect(tooltipImg.getAttribute('src')).toBe(`src/assets/art/${summoner.id}-art.png`);
     expect(tooltip.textContent).toContain(summoner.name);
     expect(tooltip.textContent).toContain(summoner.text);
+    expect(tooltip.querySelector('.stat.attack').textContent).toBe('6');
+    expect(tooltip.querySelector('.stat.health').textContent).toBe('6');
 
     global.Image = OriginalImage;
   });

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -109,8 +109,8 @@ export function renderPlay(container, game, { onUpdate } = {}) {
     } else if (tooltipCard.cost != null) {
       currentTooltip.append(el('div', { class: 'stat cost' }, tooltipCard.cost));
     }
-    if (tooltipCard.data?.attack != null) currentTooltip.append(el('div', { class: 'stat attack' }, tooltipCard.data.attack));
-    if (tooltipCard.data?.health != null) currentTooltip.append(el('div', { class: 'stat health' }, tooltipCard.data.health));
+    if (card.data?.attack != null) currentTooltip.append(el('div', { class: 'stat attack' }, card.data.attack));
+    if (card.data?.health != null) currentTooltip.append(el('div', { class: 'stat health' }, card.data.health));
 
     art.onload = () => { if (tooltipEl === currentTooltip) position(); };
     art.onerror = () => { if (tooltipEl === currentTooltip) { art.remove(); position(); } };


### PR DESCRIPTION
## Summary
- ensure tooltips display a summoned ally's attack and health
- test summoned ally tooltips show stats

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2c348f124832390e297dd00418cc9