### PR TITLE
feat: log player actions

### DIFF
--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -4,31 +4,24 @@ import { renderPlay } from '../src/js/ui/play.js';
 import Hero from '../src/js/entities/hero.js';
 
 describe('UI Play', () => {
-  test('renders hero panes with name, health, armor, and abilities', () => {
+  test('renders log panes with player and enemy actions', () => {
     const container = document.createElement('div');
-    const playerHero = new Hero({ name: 'Player Hero', data: { health: 25, armor: 5 }, text: 'Player ability', keywords: ['Swift'] });
-    const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20, armor: 3 }, text: 'Enemy ability', keywords: ['Stealth'] });
+    const playerHero = new Hero({ name: 'Player Hero', data: { health: 25, armor: 5 } });
+    const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20, armor: 3 } });
 
     const game = {
-      player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
-      opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 } },
+      player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 }, log: ['Played Card', 'Attacked Enemy'] },
+      opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 }, log: ['Played Other'] },
       resources: { pool: () => 0, available: () => 0 },
       draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true,
     };
 
     renderPlay(container, game);
 
-    const playerPane = container.querySelector('.row.player .hero-pane');
-    expect(playerPane.textContent).toContain('Player Hero');
-    expect(playerPane.textContent).toContain('Health: 25');
-    expect(playerPane.textContent).toContain('Armor: 5');
-    expect(playerPane.textContent).toContain('Player ability');
-
-    const enemyPane = container.querySelector('.row.enemy .hero-pane');
-    expect(enemyPane.textContent).toContain('Enemy Hero');
-    expect(enemyPane.textContent).toContain('Health: 20');
-    expect(enemyPane.textContent).toContain('Armor: 3');
-    expect(enemyPane.textContent).toContain('Enemy ability');
+    const playerLog = container.querySelector('.row.player .log-pane');
+    expect(playerLog.textContent).toContain('Played Card');
+    const enemyLog = container.querySelector('.row.enemy .log-pane');
+    expect(enemyLog.textContent).toContain('Played Other');
   });
 
   test('shows card tooltip with art, name, and text when art is available', () => {

--- a/src/js/entities/player.js
+++ b/src/js/entities/player.js
@@ -14,6 +14,7 @@ export class Player {
     this.resources = 0; // legacy numeric; use resourceZone + pool
     this.status = {};
     this.cardsPlayedThisTurn = 0;
+    this.log = [];
 
     this.library = new Deck('library');
     this.hand = new Hand('hand');

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -245,6 +245,7 @@ export default class Game {
     }
 
     this.bus.emit('cardPlayed', { player, card });
+    player.log.push(`Played ${card.name}`);
     player.cardsPlayedThisTurn += 1;
 
     return true;
@@ -352,6 +353,8 @@ export default class Game {
     this.combat.resolve();
     await this.cleanupDeaths(player, defender);
     await this.cleanupDeaths(defender, player);
+    const actualTarget = target || defender.hero;
+    player.log.push(`Attacked ${actualTarget.name} with ${card.name}`);
     card.data.attacked = true;
     return true;
   }
@@ -390,7 +393,9 @@ export default class Game {
           const choices = legal.filter(t => t.id !== this.player.hero.id);
           block = this.rng.pick(choices);
         }
+        const target = block || this.player.hero;
         if (block) this.combat.assignBlocker(c.id, block);
+        this.opponent.log.push(`Attacked ${target.name} with ${c.name}`);
       }
     }
     this.combat.setDefenderHero(this.player.hero);

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -30,18 +30,9 @@ function zoneList(title, cards, { clickCard, game, showTooltip, hideTooltip } = 
   return el('section', {}, el('h3', {}, title), ul);
 }
 
-function heroPane(hero) {
-  const abilities = [];
-  if (hero.text) abilities.push(el('p', { class: 'ability-text' }, hero.text));
-  if (hero.keywords?.length) {
-    const ul = el('ul', { class: 'abilities' }, ...hero.keywords.map(k => el('li', {}, k)));
-    abilities.push(ul);
-  }
-  return el('div', { class: 'hero-pane' },
-    el('h3', {}, hero.name),
-    el('p', {}, `Health: ${hero.data.health} Armor: ${hero.data.armor}`),
-    ...abilities
-  );
+function logPane(title, entries = []) {
+  const ul = el('ul', {}, ...entries.map(e => el('li', {}, e)));
+  return el('div', { class: 'log-pane' }, el('h3', {}, title), ul);
 }
 
 export function renderPlay(container, game, { onUpdate } = {}) {
@@ -142,12 +133,12 @@ export function renderPlay(container, game, { onUpdate } = {}) {
   );
 
   const playerRow = el('div', { class: 'row player' },
-    heroPane(p.hero),
+    logPane('Player Log', p.log),
     el('div', { class: 'zone' }, zoneList('Player Battlefield', [p.hero, ...p.battlefield.cards], { clickCard: async (c)=>{ await game.attack(p, c.id); onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
     el('div', { class: 'zone' }, zoneList('Player Hand', p.hand.cards, { clickCard: async (c)=>{ if (!await game.playFromHand(p, c.id)) { /* ignore */ } onUpdate?.(); }, game: game, showTooltip: showTooltip, hideTooltip: hideTooltip }))
   );
   const enemyRow = el('div', { class: 'row enemy' },
-    heroPane(e.hero),
+    logPane('Enemy Log', e.log),
     el('div', { class: 'zone' }, zoneList('Enemy Battlefield', [e.hero, ...e.battlefield.cards], { game: game, showTooltip: showTooltip, hideTooltip: hideTooltip })),
     el('div', { class: 'zone' }, el('h3', {}, 'Enemy Hand'), el('p', {}, `${e.hand.size()} cards`))
   );


### PR DESCRIPTION
## Summary
- replace hero panes with action logs
- record card plays and attacks for each player
- test log pane rendering

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c30d73bdb083239d94f81833440d98