### PR TITLE
feat: scroll logs with consistent pane height

### DIFF
--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -24,6 +24,28 @@ describe('UI Play', () => {
     expect(enemyLog.textContent).toContain('Played Other');
   });
 
+  test('log pane has zone styling and auto-scrolls to bottom', async () => {
+    const container = document.createElement('div');
+    const playerHero = new Hero({ name: 'Player Hero', data: { health: 25, armor: 5 } });
+    const enemyHero = new Hero({ name: 'Enemy Hero', data: { health: 20, armor: 3 } });
+
+    const entries = Array.from({ length: 20 }, (_, i) => `Entry ${i}`);
+    const game = {
+      player: { hero: playerHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 }, log: entries },
+      opponent: { hero: enemyHero, battlefield: { cards: [] }, hand: { cards: [], size: () => 0 }, log: [] },
+      resources: { pool: () => 0, available: () => 0 },
+      draw: jest.fn(), attack: jest.fn(), endTurn: jest.fn(), playFromHand: () => true,
+    };
+
+    renderPlay(container, game);
+    await new Promise(r => setTimeout(r, 0));
+
+    const pane = container.querySelector('.row.player .log-pane');
+    const list = pane.querySelector('ul');
+    expect(pane.classList.contains('zone')).toBe(true);
+    expect(list.scrollTop + list.clientHeight).toBe(list.scrollHeight);
+  });
+
   test('shows card tooltip with art, name, and text when art is available', () => {
     const OriginalImage = global.Image;
     global.Image = class {

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -32,7 +32,10 @@ function zoneList(title, cards, { clickCard, game, showTooltip, hideTooltip } = 
 
 function logPane(title, entries = []) {
   const ul = el('ul', {}, ...entries.map(e => el('li', {}, e)));
-  return el('div', { class: 'log-pane' }, el('h3', {}, title), ul);
+  const pane = el('div', { class: 'log-pane zone' }, el('h3', {}, title), ul);
+  // Ensure the latest entries are visible
+  setTimeout(() => { ul.scrollTop = ul.scrollHeight; });
+  return pane;
 }
 
 export function renderPlay(container, game, { onUpdate } = {}) {

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,19 @@ footer {
   border-radius: 4px;
 }
 
+.log-pane {
+  display: flex;
+  flex-direction: column;
+}
+
+.log-pane ul {
+  flex: 1;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+}
+
 ul.zone-list {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- style player and enemy logs like other panes
- keep log lists scrolled to the latest entry
- test log pane styling and auto-scroll

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c315f453648323b5ad65d688ce80dc