### PR TITLE
feat: add Stone Bark Treant armor synergy

### DIFF
--- a/CARDS.md
+++ b/CARDS.md
@@ -406,7 +406,7 @@ Conventions
 - Type: Ally — Elemental (Druid)
 - Cost: 5; Rarity: Common
 - Stats: 4 ATK / 6 HP
-- Text: Taunt. If you gained Armor this turn, gain +0/+2.
+- Text: Taunt. Whenever your hero gains Armor, gain +0/+2.
 - Keywords: Taunt, Treant
 - Systems: Guardian talents reward Armor lines; PvE wall.
 - Art: Massive tree‑being with granite plates and glowing eyes.

--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -233,6 +233,18 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         expect(demon.data.health).toBe(2);
         break;
       }
+      case 'buffOnArmorGain': {
+        g.player.hand.add(new Card(card));
+        const treant = g.player.hand.cards[0];
+        await g.playFromHand(g.player, treant.id);
+        const before = treant.data.health;
+        await g.effects.execute(
+          [{ type: 'buff', target: 'hero', property: 'armor', amount: 2 }],
+          { game: g, player: g.player, card: g.player.hero }
+        );
+        expect(treant.data.health).toBe(before + effect.health);
+        break;
+      }
       case 'drawOnHeal': {
         await g.playFromHand(g.player, card.id);
         const handBefore = g.player.hand.cards.length;

--- a/__tests__/stone-bark-treant.armor.test.js
+++ b/__tests__/stone-bark-treant.armor.test.js
@@ -1,0 +1,49 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+const getTreant = (g) => new Card(g.allCards.find(c => c.id === 'ally-stone-bark-treant'));
+
+test('Stone Bark Treant does not gain +0/+2 from armor gained before it entered play', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+
+  await g.effects.execute(
+    [{ type: 'buff', target: 'hero', property: 'armor', amount: 2 }],
+    { game: g, player: g.player, card: g.player.hero }
+  );
+
+  const treant = getTreant(g);
+  g.player.hand.add(treant);
+  await g.playFromHand(g.player, treant.id);
+
+  expect(treant.data.health).toBe(6);
+});
+
+test('Stone Bark Treant gains +0/+2 whenever its hero gains armor', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+
+  const treant = getTreant(g);
+  g.player.hand.add(treant);
+  await g.playFromHand(g.player, treant.id);
+
+  expect(treant.data.health).toBe(6);
+
+  await g.effects.execute(
+    [{ type: 'buff', target: 'hero', property: 'armor', amount: 2 }],
+    { game: g, player: g.player, card: g.player.hero }
+  );
+
+  expect(treant.data.health).toBe(8);
+});
+

--- a/data/cards.json
+++ b/data/cards.json
@@ -840,8 +840,9 @@
     "cost": 5,
     "effects": [
       {
-        "type": "rawText",
-        "text": "Taunt. If you gained Armor this turn, gain +0/+2."
+        "type": "buffOnArmorGain",
+        "attack": 0,
+        "health": 2
       }
     ],
     "keywords": [
@@ -853,7 +854,7 @@
       "attack": 4,
       "health": 6
     },
-    "text": "Taunt. If you gained Armor this turn, gain +0/+2."
+    "text": "Taunt. Whenever your hero gains Armor, gain +0/+2."
   },
   {
     "id": "ally-defias-footpad",

--- a/src/js/entities/player.js
+++ b/src/js/entities/player.js
@@ -14,6 +14,7 @@ export class Player {
     this.resources = 0; // legacy numeric; use resourceZone + pool
     this.status = {};
     this.cardsPlayedThisTurn = 0;
+    this.armorGainedThisTurn = 0;
     this.log = [];
 
     this.library = new Deck('library');

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -31,7 +31,10 @@ export default class Game {
     this.quests = new QuestSystem(this);
 
     this.turns.bus.on('turn:start', ({ player }) => {
-      if (player) player.cardsPlayedThisTurn = 0;
+      if (player) {
+        player.cardsPlayedThisTurn = 0;
+        player.armorGainedThisTurn = 0;
+      }
       const bonus = player?.hero?.data?.nextSpellDamageBonus;
       if (bonus?.eachTurn) bonus.used = false;
       if (player?.hero) {


### PR DESCRIPTION
## Summary
- gate Stone Bark Treant's buff so it only triggers on armor gained while in play
- update Stone Bark Treant card text and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c31b9a91c0832393302d10f301b0d5