### PR TITLE
fix: apply combo damage correctly for Eviscerate

### DIFF
--- a/__tests__/eviscerate.combo.test.js
+++ b/__tests__/eviscerate.combo.test.js
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import { jest } from '@jest/globals';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+const cards = JSON.parse(
+  fs.readFileSync(new URL('../data/cards.json', import.meta.url))
+);
+const eviscerateData = cards.find(c => c.id === 'spell-eviscerate');
+
+describe('Eviscerate combo', () => {
+  test('deals 4 damage when combo is active', async () => {
+    const g = new Game();
+    g.resources._pool.set(g.player, 10);
+    const filler = new Card({ type: 'spell', name: 'Filler', cost: 0 });
+    const eviscerate = new Card(eviscerateData);
+    g.player.hand.add(filler);
+    g.player.hand.add(eviscerate);
+    await g.playFromHand(g.player, filler.id);
+    const promptSpy = jest.fn(async () => g.opponent.hero);
+    g.promptTarget = promptSpy;
+    await g.playFromHand(g.player, eviscerate.id);
+    expect(promptSpy).toHaveBeenCalled();
+    expect(g.opponent.hero.data.health).toBe(26);
+  });
+
+  test('deals 2 damage without combo', async () => {
+    const g = new Game();
+    g.resources._pool.set(g.player, 10);
+    const eviscerate = new Card(eviscerateData);
+    g.player.hand.add(eviscerate);
+    const promptSpy = jest.fn(async () => g.opponent.hero);
+    g.promptTarget = promptSpy;
+    await g.playFromHand(g.player, eviscerate.id);
+    expect(promptSpy).toHaveBeenCalled();
+    expect(g.opponent.hero.data.health).toBe(28);
+  });
+});

--- a/data/cards.json
+++ b/data/cards.json
@@ -294,16 +294,11 @@
       {
         "type": "damage",
         "target": "any",
-        "amount": 2
+        "amount": 2,
+        "comboAmount": 4
       }
     ],
-    "combo": [
-      {
-        "type": "damage",
-        "target": "any",
-        "amount": 4
-      }
-    ],
+    "combo": [],
     "keywords": [
       "Combo"
     ],

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -91,10 +91,13 @@ export class EffectSystem {
   }
 
   async dealDamage(effect, context) {
-    const { target, amount, freeze, beastBonus } = effect;
-    const { game, player, card } = context;
+    const { target, amount, freeze, beastBonus, comboAmount } = effect;
+    const { game, player, card, comboActive } = context;
     const opponent = player === game.player ? game.opponent : game.player;
       let dmgAmount = amount;
+      if (comboActive && typeof comboAmount === 'number') {
+        dmgAmount = comboAmount;
+      }
       if (beastBonus) {
         const hasBeast = player.battlefield.cards.some(c => c.keywords?.includes('Beast'));
         if (hasBeast) dmgAmount += beastBonus;


### PR DESCRIPTION
## Summary
- ensure spells with combo only apply combo effects once
- support combo-specific damage values
- test Eviscerate damage with and without combo

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c335ec97888323b94b0ca197160960