### PR TITLE
fix: share target for multi-stat buffs

### DIFF
--- a/__tests__/systems.effects.test.js
+++ b/__tests__/systems.effects.test.js
@@ -123,5 +123,26 @@ describe('EffectSystem', () => {
     expect(player.hero.data.health).toBe(6);
     expect(ally.data.health).toBe(1);
   });
+
+  test('buffing attack and health prompts for one target', async () => {
+    const game = new Game();
+    const player = game.player;
+    const ally = new Card({ type: 'ally', name: 'Ally', data: { attack: 1, health: 1 } });
+    player.battlefield.add(ally);
+
+    const promptSpy = jest.fn(async () => ally);
+    game.promptTarget = promptSpy;
+
+    const effects = [
+      { type: 'buff', target: 'character', property: 'attack', amount: 4 },
+      { type: 'buff', target: 'character', property: 'health', amount: 4 },
+    ];
+
+    await game.effects.execute(effects, { game, player, card: null });
+
+    expect(promptSpy).toHaveBeenCalledTimes(1);
+    expect(ally.data.attack).toBe(5);
+    expect(ally.data.health).toBe(5);
+  });
 });
 


### PR DESCRIPTION
## Summary
- only prompt once when a card grants both attack and health buffs to a single ally
- reuse selected target when applying multiple buffs
- add test ensuring +X/+X buffs request one target

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3bb652b548323a873a8b80d350970