### PR TITLE
Fix Benediction healing draw trigger

### DIFF
--- a/__tests__/benediction.heal-draw.test.js
+++ b/__tests__/benediction.heal-draw.test.js
@@ -1,0 +1,34 @@
+import Game from '../src/js/game.js';
+
+describe('Benediction', () => {
+  test('draws only after healing 5 or more in a turn', async () => {
+    const g = new Game();
+    await g.setupMatch();
+    g.resources._pool.set(g.player, 10);
+    const initialHand = g.player.hand.cards.length;
+    g.addCardToHand('equipment-benediction');
+    await g.playFromHand(g.player, 'equipment-benediction');
+    expect(g.player.hand.cards.length).toBe(initialHand);
+
+    g.player.hero.data.maxHealth = 30;
+    g.player.hero.data.health = 25;
+
+    await g.effects.healCharacter({ target: 'hero', amount: 3 }, { game: g, player: g.player, card: null });
+    expect(g.player.hand.cards.length).toBe(initialHand);
+
+    await g.effects.healCharacter({ target: 'hero', amount: 2 }, { game: g, player: g.player, card: null });
+    expect(g.player.hand.cards.length).toBe(initialHand + 1);
+
+    await g.effects.healCharacter({ target: 'hero', amount: 1 }, { game: g, player: g.player, card: null });
+    expect(g.player.hand.cards.length).toBe(initialHand + 1);
+
+    g.turns.setActivePlayer(g.player);
+    g.turns.startTurn();
+    g.resources.startTurn(g.player);
+    g.player.hero.data.health = 25;
+    const handAtTurnStart = g.player.hand.cards.length;
+
+    await g.effects.healCharacter({ target: 'hero', amount: 5 }, { game: g, player: g.player, card: null });
+    expect(g.player.hand.cards.length).toBe(handAtTurnStart + 1);
+  });
+});

--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -247,8 +247,11 @@ describe.each(effectCards)('$id executes its effect', (card) => {
       }
       case 'drawOnHeal': {
         await g.playFromHand(g.player, card.id);
+        g.player.hero.data.maxHealth = 30;
+        g.player.hero.data.health = 20;
         const handBefore = g.player.hand.cards.length;
-        await g.effects.healCharacter({ target: 'hero', amount: 1 }, { game: g, player: g.player, card: null });
+        const healAmount = Math.max(1, effect.threshold ?? 0);
+        await g.effects.healCharacter({ target: 'hero', amount: healAmount }, { game: g, player: g.player, card: null });
         expect(g.player.hand.cards.length).toBe(handBefore + effect.count);
         break;
       }

--- a/data/cards.json
+++ b/data/cards.json
@@ -934,8 +934,9 @@
     "cost": 4,
     "effects": [
       {
-        "type": "draw",
-        "count": 1
+        "type": "drawOnHeal",
+        "count": 1,
+        "threshold": 5
       }
     ],
     "keywords": [

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -381,19 +381,25 @@ export class EffectSystem {
   }
 
   drawOnHeal(effect, context) {
-    const { count = 1 } = effect;
+    const { count = 1, threshold = 0 } = effect;
     const { game, player, card } = context;
 
-    const handler = ({ player: healedPlayer }) => {
+    const handler = ({ player: healedPlayer, amount }) => {
       if (healedPlayer !== player) return;
       card.data = card.data || {};
+      card.data.healedThisTurn = (card.data.healedThisTurn || 0) + amount;
       if (card.data.drawnThisTurn) return;
-      game.draw(player, count);
-      card.data.drawnThisTurn = true;
+      if (card.data.healedThisTurn >= threshold) {
+        game.draw(player, count);
+        card.data.drawnThisTurn = true;
+      }
     };
 
     const reset = ({ player: turnPlayer }) => {
-      if (turnPlayer === player && card.data) card.data.drawnThisTurn = false;
+      if (turnPlayer === player && card.data) {
+        card.data.drawnThisTurn = false;
+        card.data.healedThisTurn = 0;
+      }
     };
 
     const offHeal = game.bus.on('characterHealed', handler);


### PR DESCRIPTION
## Summary
- require Benediction to use draw-on-heal effect with a 5 HP threshold
- track per-turn healing in `drawOnHeal` effect so draws occur only after meeting the threshold
- add Benediction test and adjust generic draw-on-heal test for thresholds

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3c1efacd8832381e2fdc701c34f70