### PR TITLE
fix: reset mana after reload

### DIFF
--- a/__tests__/game.reset.mana.test.js
+++ b/__tests__/game.reset.mana.test.js
@@ -1,0 +1,14 @@
+import Game from '../src/js/game.js';
+
+describe('Game.reset', () => {
+  test('resets turn and mana pool', async () => {
+    const g = new Game(null);
+    await g.init();
+    g.turns.turn = 5;
+    g.resources.startTurn(g.player);
+    expect(g.resources.pool(g.player)).toBe(5);
+    await g.reset();
+    expect(g.turns.turn).toBe(1);
+    expect(g.resources.pool(g.player)).toBe(1);
+  });
+});

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -451,6 +451,10 @@ export default class Game {
   async reset(playerDeck = null) {
     this.state.frame = 0;
     this.state.startedAt = 0;
+    this.turns.turn = 1;
+    this.turns.current = 'Start';
+    this.turns.activePlayer = null;
+    this.resources = new ResourceSystem(this.turns);
     this.player = new Player({ name: 'You' });
     this.opponent = new Player({ name: 'AI' });
     await this.setupMatch(playerDeck);


### PR DESCRIPTION
## Summary
- reset turn state and mana pools when resetting the game
- add regression test for mana reset

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3c7c22ce883239edaf1a59207b4e9