### PR TITLE
fix: prevent AI from attacking with summoning-sick allies

### DIFF
--- a/__tests__/ai.summoning-sickness.test.js
+++ b/__tests__/ai.summoning-sickness.test.js
@@ -1,0 +1,20 @@
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+import BasicAI from '../src/js/systems/ai.js';
+
+test('AI does not attack with summoning-sick ally', () => {
+  const g = new Game();
+  const ai = new BasicAI({ resourceSystem: g.resources, combatSystem: g.combat });
+  g.player.hero = new Hero({ name: 'AI', data: { health: 10 } });
+  g.opponent.hero = new Hero({ name: 'Opponent', data: { health: 10 } });
+  const ally = new Card({ type: 'ally', name: 'Footman', cost: 0, data: { attack: 1, health: 1 } });
+  g.player.hand.add(ally);
+  g.turns.setActivePlayer(g.player);
+  g.turns.startTurn();
+  ai.takeTurn(g.player, g.opponent);
+  const played = g.player.battlefield.cards.find(c => c.name === 'Footman');
+  expect(played.data.attacked).toBe(true);
+  expect(g.opponent.hero.data.health).toBe(10);
+});
+

--- a/src/js/systems/ai.js
+++ b/src/js/systems/ai.js
@@ -22,6 +22,10 @@ export class BasicAI {
       if (card.type === 'ally' || card.type === 'equipment' || card.type === 'quest') {
         player.hand.moveTo(player.battlefield, card.id);
         if (card.type === 'equipment') player.hero.equipment.push(card);
+        if (card.type === 'ally' && !card.keywords?.includes('Rush')) {
+          card.data = card.data || {};
+          card.data.attacked = true;
+        }
       } else {
         player.hand.moveTo(player.graveyard, card.id);
       }


### PR DESCRIPTION
## Summary
- ensure BasicAI marks non-Rush allies as having attacked so they can't attack immediately
- add test confirming AI skips summoning-sick allies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4743c570c8323b66e5afb9c7f9b39