### PR TITLE
feat: implement heuristic-based AI decision making

### DIFF
--- a/__tests__/ai.heuristics.test.js
+++ b/__tests__/ai.heuristics.test.js
@@ -1,0 +1,32 @@
+import Player from '../src/js/entities/player.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+import Game from '../src/js/game.js';
+import BasicAI from '../src/js/systems/ai.js';
+import { evaluateGameState } from '../src/js/systems/ai-heuristics.js';
+
+test('evaluateGameState favors stronger board', () => {
+  const ai = new Player({ name: 'AI', hero: new Hero({ name: 'AI', data: { health: 10 } }) });
+  const opponent = new Player({ name: 'OP', hero: new Hero({ name: 'OP', data: { health: 10 } }) });
+  const turn = 1;
+  const base = evaluateGameState({ player: ai, opponent, turn });
+  const ally = new Card({ type: 'ally', name: 'Soldier', data: { attack: 1, health: 1 } });
+  ai.battlefield.cards.push(ally);
+  const improved = evaluateGameState({ player: ai, opponent, turn });
+  expect(improved).toBeGreaterThan(base);
+});
+
+test('AI heals itself when injured', () => {
+  const g = new Game();
+  const ai = new BasicAI({ resourceSystem: g.resources, combatSystem: g.combat });
+  g.turns.turn = 5;
+  g.player.library.cards = [];
+  g.player.hero.data.maxHealth = 30;
+  g.player.hero.data.health = 20;
+  const potion = new Card({ type: 'consumable', name: 'Healing Potion', cost: 1, effects: [{ type: 'heal', target: 'character', amount: 5 }] });
+  g.player.hand.add(potion);
+  g.turns.setActivePlayer(g.player);
+  ai.takeTurn(g.player, g.opponent);
+  expect(g.player.hero.data.health).toBe(25);
+  expect(g.player.graveyard.cards).toContain(potion);
+});

--- a/src/js/systems/ai-heuristics.js
+++ b/src/js/systems/ai-heuristics.js
@@ -1,0 +1,65 @@
+export const TURN_WEIGHT = 0.1;
+export const AI_HEALTH_WEIGHT = 5;
+export const PLAYER_HEALTH_WEIGHT = -5;
+export const AI_HAND_WEIGHT = 1;
+export const PLAYER_HAND_WEIGHT = -1;
+export const AI_BOARD_ALLY_WEIGHT = 3;
+export const PLAYER_BOARD_ALLY_WEIGHT = -3;
+export const AI_EQUIPMENT_WEIGHT = 2;
+export const PLAYER_EQUIPMENT_WEIGHT = -2;
+export const AI_GRAVEYARD_WEIGHT = 0.5;
+export const PLAYER_GRAVEYARD_WEIGHT = -0.5;
+export const RESOURCE_WEIGHT = -0.3;
+export const TAUNT_WEIGHT = 2;
+export const FREEZE_WEIGHT = -2;
+export const WIN_CONDITION_BONUS = 1000;
+
+function countKeyword(cards, keyword) {
+  return cards.filter(c => c?.keywords?.includes?.(keyword)).length;
+}
+
+function countFrozen(player) {
+  const chars = [player.hero, ...(player.battlefield?.cards || [])];
+  return chars.filter(c => (c?.data?.freezeTurns || 0) > 0).length;
+}
+
+export function evaluateGameState({ player, opponent, turn = 1, resources = 0 }) {
+  let score = 0;
+
+  const aiHealth = player.hero?.data?.health ?? 0;
+  const oppHealth = opponent.hero?.data?.health ?? 0;
+  score += aiHealth * AI_HEALTH_WEIGHT;
+  score += oppHealth * PLAYER_HEALTH_WEIGHT;
+
+  score += (player.hand?.cards?.length || 0) * AI_HAND_WEIGHT;
+  score += (opponent.hand?.cards?.length || 0) * PLAYER_HAND_WEIGHT;
+
+  const aiAllies = player.battlefield?.cards?.filter?.(c => c.type === 'ally').length || 0;
+  const oppAllies = opponent.battlefield?.cards?.filter?.(c => c.type === 'ally').length || 0;
+  score += aiAllies * AI_BOARD_ALLY_WEIGHT;
+  score += oppAllies * PLAYER_BOARD_ALLY_WEIGHT;
+
+  const aiEq = player.hero?.equipment?.length || 0;
+  const oppEq = opponent.hero?.equipment?.length || 0;
+  score += aiEq * AI_EQUIPMENT_WEIGHT;
+  score += oppEq * PLAYER_EQUIPMENT_WEIGHT;
+
+  score += (player.graveyard?.cards?.length || 0) * AI_GRAVEYARD_WEIGHT;
+  score += (opponent.graveyard?.cards?.length || 0) * PLAYER_GRAVEYARD_WEIGHT;
+
+  score += resources * RESOURCE_WEIGHT;
+  score += turn * TURN_WEIGHT;
+
+  score += countKeyword(player.battlefield?.cards || [], 'Taunt') * TAUNT_WEIGHT;
+  score -= countKeyword(opponent.battlefield?.cards || [], 'Taunt') * TAUNT_WEIGHT;
+
+  score += countFrozen(opponent) * -FREEZE_WEIGHT; // frozen enemy is good -> subtract negative
+  score += countFrozen(player) * FREEZE_WEIGHT;
+
+  if (oppHealth <= 0) score += WIN_CONDITION_BONUS;
+  if (aiHealth <= 0) score -= WIN_CONDITION_BONUS;
+
+  return score;
+}
+
+export default evaluateGameState;

--- a/src/js/systems/ai.js
+++ b/src/js/systems/ai.js
@@ -1,3 +1,6 @@
+import CombatSystem from './combat.js';
+import { evaluateGameState } from './ai-heuristics.js';
+
 export class BasicAI {
   constructor({ resourceSystem, combatSystem } = {}) {
     this.resources = resourceSystem;
@@ -36,43 +39,145 @@ export class BasicAI {
     return !useful;
   }
 
+  _applySimpleEffects(effects = [], player, opponent, pool) {
+    for (const e of effects) {
+      const amt = e.amount || 0;
+      switch (e.type) {
+        case 'heal': {
+          const chars = [player.hero, ...player.battlefield.cards];
+          const target = chars.find(c => {
+            const cur = c.data?.health ?? c.health;
+            const max = c.data?.maxHealth ?? c.maxHealth ?? cur;
+            return cur < max;
+          });
+          if (target) {
+            const max = target.data?.maxHealth ?? target.maxHealth ?? 30;
+            target.data.health = Math.min(max, (target.data?.health ?? target.health) + amt);
+          }
+          break;
+        }
+        case 'damage': {
+          const chars = [opponent.hero, ...opponent.battlefield.cards];
+          const target = chars[0];
+          if (target) {
+            target.data.health = Math.max(0, (target.data?.health ?? target.health) - amt);
+          }
+          break;
+        }
+        case 'restore': {
+          const avail = this.resources.available(player);
+          pool = Math.min(avail, pool + amt);
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    return pool;
+  }
+
+  _simulateAction(player, opponent, { card = null, usePower = false } = {}, pool = 0) {
+    const p = structuredClone(player);
+    const o = structuredClone(opponent);
+    let res = pool;
+
+    if (card) {
+      res -= card.cost || 0;
+      p.hand.cards = p.hand.cards.filter(c => c.id !== card.id);
+      const played = structuredClone(card);
+      if (played.type === 'ally' || played.type === 'equipment' || played.type === 'quest') {
+        p.battlefield.cards.push(played);
+        if (played.type === 'equipment') {
+          p.hero.equipment = p.hero.equipment || [];
+          p.hero.equipment.push(played);
+        }
+        if (played.type === 'ally' && !played.keywords?.includes('Rush')) {
+          played.data = played.data || {};
+          played.data.attacked = true;
+        }
+      } else {
+        p.graveyard.cards.push(played);
+      }
+      if (played.effects) res = this._applySimpleEffects(played.effects, p, o, res);
+    }
+
+    if (usePower) {
+      res -= 2;
+      p.hero.powerUsed = true;
+      if (p.hero.active) res = this._applySimpleEffects(p.hero.active, p, o, res);
+    }
+
+    const combat = new CombatSystem();
+    const attackers = [p.hero, ...(p.battlefield?.cards || [])]
+      .filter(c => (c.type !== 'equipment') && !c.data?.attacked && ((typeof c.totalAttack === 'function' ? c.totalAttack() : c.data?.attack || 0) > 0));
+    for (const a of attackers) {
+      if (combat.declareAttacker(a)) {
+        if (a.data) a.data.attacked = true;
+      }
+    }
+    combat.setDefenderHero(o.hero);
+    combat.resolve();
+
+    for (const pl of [p, o]) {
+      const dead = pl.battlefield.cards.filter(c => c.data?.dead);
+      for (const d of dead) {
+        pl.graveyard.cards.push(d);
+        pl.battlefield.cards = pl.battlefield.cards.filter(c => c.id !== d.id);
+      }
+    }
+
+    return evaluateGameState({ player: p, opponent: o, turn: this.resources.turns.turn, resources: res });
+  }
+
   takeTurn(player, opponent = null) {
-    // Refresh available resources for the turn
     this.resources.startTurn(player);
 
-    // Draw one card if possible
     const drawn = player.library.draw(1);
     if (drawn[0]) player.hand.add(drawn[0]);
 
-    // Play the cheapest affordable card from hand
-    const affordable = player.hand.cards
-      .filter(c => this.resources.canPay(player, c.cost || 0))
-      .filter(c => !this._effectsAreUseless(c.effects, player))
-      .sort((a, b) => (a.cost || 0) - (b.cost || 0));
-    const card = affordable[0];
-    if (card) {
-      this.resources.pay(player, card.cost || 0);
-      if (card.type === 'ally' || card.type === 'equipment' || card.type === 'quest') {
-        player.hand.moveTo(player.battlefield, card.id);
-        if (card.type === 'equipment') player.hero.equipment.push(card);
-        if (card.type === 'ally' && !card.keywords?.includes('Rush')) {
-          card.data = card.data || {};
-          card.data.attacked = true;
+    const pool = this.resources.pool(player);
+
+    const actions = [{ card: null, usePower: false }];
+    const canPower = player.hero?.active?.length && !player.hero.powerUsed && pool >= 2 &&
+      !this._effectsAreUseless(player.hero.active, player);
+    if (canPower) actions.push({ card: null, usePower: true });
+
+    for (const c of player.hand.cards) {
+      if (!this.resources.canPay(player, c.cost || 0)) continue;
+      if (this._effectsAreUseless(c.effects, player)) continue;
+      actions.push({ card: c, usePower: false });
+      if (canPower && pool - (c.cost || 0) >= 2) actions.push({ card: c, usePower: true });
+    }
+
+    let best = actions[0];
+    let bestScore = -Infinity;
+    for (const act of actions) {
+      const score = this._simulateAction(player, opponent, act, pool);
+      if (score > bestScore) { bestScore = score; best = act; }
+    }
+
+    if (best.card) {
+      this.resources.pay(player, best.card.cost || 0);
+      if (best.card.effects) this._applySimpleEffects(best.card.effects, player, opponent, pool);
+      if (best.card.type === 'ally' || best.card.type === 'equipment' || best.card.type === 'quest') {
+        player.hand.moveTo(player.battlefield, best.card.id);
+        if (best.card.type === 'equipment') player.hero.equipment.push(best.card);
+        if (best.card.type === 'ally' && !best.card.keywords?.includes('Rush')) {
+          best.card.data = best.card.data || {};
+          best.card.data.attacked = true;
         }
       } else {
-        player.hand.moveTo(player.graveyard, card.id);
+        player.hand.moveTo(player.graveyard, best.card.id);
       }
       player.cardsPlayedThisTurn += 1;
     }
 
-    // Use hero power if available and affordable (cost 2)
-    if (player.hero?.active?.length && !player.hero.powerUsed && this.resources.canPay(player, 2) &&
-        !this._effectsAreUseless(player.hero.active, player)) {
+    if (best.usePower) {
       this.resources.pay(player, 2);
       player.hero.powerUsed = true;
+      if (player.hero.active) this._applySimpleEffects(player.hero.active, player, opponent, pool);
     }
 
-    // Declare simple attacks against the opponent hero
     if (this.combat && opponent) {
       this.combat.clear();
       const attackers = [player.hero, ...player.battlefield.cards]
@@ -85,7 +190,6 @@ export class BasicAI {
       this.combat.setDefenderHero(opponent.hero);
       this.combat.resolve();
 
-      // Cleanup defeated allies
       for (const p of [player, opponent]) {
         const dead = p.battlefield.cards.filter(c => c.data?.dead);
         for (const d of dead) {
@@ -99,4 +203,3 @@ export class BasicAI {
 }
 
 export default BasicAI;
-


### PR DESCRIPTION
## Summary
- add tunable heuristic weights and evaluation for game states
- upgrade AI to simulate actions and select highest-scoring move
- test heuristic scoring and healing behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c48dc117748323b434dfe449995414