### PR TITLE
fix: penalize wasted resources in AI heuristics

### DIFF
--- a/__tests__/ai.useless-actions.test.js
+++ b/__tests__/ai.useless-actions.test.js
@@ -44,6 +44,18 @@ test('AI skips healing hero power when at full health', () => {
   expect(g.resources.pool(g.player)).toBe(g.resources.available(g.player));
 });
 
+test('AI skips hero power with no effect', () => {
+  const g = new Game();
+  const ai = new BasicAI({ resourceSystem: g.resources, combatSystem: g.combat });
+  g.turns.turn = 2;
+  g.player.hero.active = [{ type: 'damage', amount: 0 }];
+  g.player.library.cards = [];
+  g.turns.setActivePlayer(g.player);
+  ai.takeTurn(g.player, g.opponent);
+  expect(g.player.hero.powerUsed).toBe(false);
+  expect(g.resources.pool(g.player)).toBe(g.resources.available(g.player));
+});
+
 test('AI does not target itself with damage spells', async () => {
   const g = new Game();
   g.player.hero.data.maxHealth = 30;

--- a/__tests__/systems.modes_ai.test.js
+++ b/__tests__/systems.modes_ai.test.js
@@ -24,7 +24,11 @@ describe('Game Modes & AI', () => {
     const s = new SkirmishMode();
     s.setup();
     s.turns.turn = 2; // ensure 2 resources for hero power
-    s.opponent.hero = new Hero({ name: 'AI Hero', data: { attack: 1 }, active: [{}] });
+    s.opponent.hero = new Hero({
+      name: 'AI Hero',
+      data: { attack: 1 },
+      active: [{ type: 'damage', amount: 1 }],
+    });
     const ally = new Card({ type: 'ally', name: 'Grunt', cost: 0, data: { attack: 1, health: 1 } });
     s.opponent.hand.add(ally);
     const initialHealth = s.player.hero.data.health;

--- a/src/js/systems/ai-heuristics.js
+++ b/src/js/systems/ai-heuristics.js
@@ -9,7 +9,10 @@ export const AI_EQUIPMENT_WEIGHT = 2;
 export const PLAYER_EQUIPMENT_WEIGHT = -2;
 export const AI_GRAVEYARD_WEIGHT = 0.5;
 export const PLAYER_GRAVEYARD_WEIGHT = -0.5;
-export const RESOURCE_WEIGHT = -0.3;
+// Spending resources alone shouldn't improve the score.
+// Positive weight encourages saving resources so actions that
+// don't meaningfully change the game state aren't preferred.
+export const RESOURCE_WEIGHT = 0.3;
 export const TAUNT_WEIGHT = 2;
 export const FREEZE_WEIGHT = -2;
 export const WIN_CONDITION_BONUS = 1000;


### PR DESCRIPTION
## Summary
- discourage pointless actions by valuing unspent resources in heuristic scoring
- ensure AI skips hero power with no effect and update mode test to use damaging hero power

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c490f638b483238dd30f919521d4fb