### PR TITLE
fix: apply summoning sickness to AI summons

### DIFF
--- a/__tests__/ai.summoning-sickness.test.js
+++ b/__tests__/ai.summoning-sickness.test.js
@@ -18,3 +18,25 @@ test('AI does not attack with summoning-sick ally', () => {
   expect(g.opponent.hero.data.health).toBe(10);
 });
 
+test('AI does not attack with summoned ally', () => {
+  const g = new Game();
+  const ai = new BasicAI({ resourceSystem: g.resources, combatSystem: g.combat });
+  g.player.hero = new Hero({ name: 'AI', data: { health: 10 } });
+  g.opponent.hero = new Hero({ name: 'Opponent', data: { health: 10 } });
+  const spell = new Card({
+    type: 'spell',
+    name: 'Summon',
+    cost: 0,
+    effects: [
+      { type: 'summon', unit: { name: 'Token', attack: 1, health: 1, keywords: [] }, count: 1 }
+    ]
+  });
+  g.player.hand.add(spell);
+  g.turns.setActivePlayer(g.player);
+  g.turns.startTurn();
+  ai.takeTurn(g.player, g.opponent);
+  const summoned = g.player.battlefield.cards.find(c => c.name === 'Token');
+  expect(summoned.data.attacked).toBe(true);
+  expect(g.opponent.hero.data.health).toBe(10);
+});
+

--- a/src/js/systems/ai.js
+++ b/src/js/systems/ai.js
@@ -1,5 +1,6 @@
 import CombatSystem from './combat.js';
 import { evaluateGameState } from './ai-heuristics.js';
+import Card from '../entities/card.js';
 
 export class BasicAI {
   constructor({ resourceSystem, combatSystem } = {}) {
@@ -61,6 +62,22 @@ export class BasicAI {
           const target = chars[0];
           if (target) {
             target.data.health = Math.max(0, (target.data?.health ?? target.health) - amt);
+          }
+          break;
+        }
+        case 'summon': {
+          const { unit, count } = e;
+          for (let i = 0; i < count; i++) {
+            const summoned = new Card({
+              name: unit.name,
+              type: 'ally',
+              data: { attack: unit.attack, health: unit.health },
+              keywords: unit.keywords
+            });
+            if (!summoned.keywords?.includes('Rush')) {
+              summoned.data.attacked = true;
+            }
+            player.battlefield.cards.push(summoned);
           }
           break;
         }


### PR DESCRIPTION
## Summary
- mark AI-summoned allies as having summoning sickness unless they have Rush
- test that AI avoids attacking with newly summoned allies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c493dc19a08323a2139a0f2cbd7c87