### PR TITLE
feat: limit deck to single quest

### DIFF
--- a/__tests__/ui.deckbuilder.test.js
+++ b/__tests__/ui.deckbuilder.test.js
@@ -21,4 +21,21 @@ describe('deckbuilder UI', () => {
     rerender();
     expect(container.textContent).toContain('Cards: 60/60');
   });
+
+  test('only allows a single quest', () => {
+    const hero = { id: 'h1', name: 'Hero', type: 'hero', text: '', data: { armor: 0 } };
+    const quest1 = { id: 'q1', name: 'Quest1', type: 'quest', text: '' };
+    const quest2 = { id: 'q2', name: 'Quest2', type: 'quest', text: '' };
+    const allCards = [hero, quest1, quest2];
+    const state = { hero: null, cards: [] };
+    const container = document.createElement('div');
+    const rerender = () => renderDeckBuilder(container, { state, allCards, onChange: rerender });
+    rerender();
+    const tips = container.querySelectorAll('.card-tooltip');
+    // add first quest
+    tips[1].dispatchEvent(new window.Event('click'));
+    // attempt to add second quest
+    tips[2].dispatchEvent(new window.Event('click'));
+    expect(state.cards.filter(c => c.type === 'quest')).toHaveLength(1);
+  });
 });

--- a/__tests__/utils.deckbuilder.test.js
+++ b/__tests__/utils.deckbuilder.test.js
@@ -1,0 +1,18 @@
+import { fillDeckRandomly } from '../src/js/utils/deckbuilder.js';
+import { RNG } from '../src/js/utils/rng.js';
+
+describe('fillDeckRandomly', () => {
+  test('ensures at most one quest in deck', () => {
+    const hero = { id: 'h1', name: 'Hero', type: 'hero', text: '', data: { armor: 0 } };
+    const quest1 = { id: 'q1', name: 'Quest1', type: 'quest', text: '' };
+    const quest2 = { id: 'q2', name: 'Quest2', type: 'quest', text: '' };
+    const ally = { id: 'a1', name: 'Ally', type: 'ally', text: '', cost: 1, data: { attack: 1, health: 1 } };
+    const allCards = [hero, quest1, quest2, ally];
+    const state = { hero, cards: [quest1, quest2] };
+    fillDeckRandomly(state, allCards, new RNG(1));
+    const quests = state.cards.filter(c => c.type === 'quest');
+    expect(quests).toHaveLength(1);
+    expect(state.cards).toHaveLength(60);
+  });
+});
+

--- a/src/js/ui/deckbuilder.js
+++ b/src/js/ui/deckbuilder.js
@@ -46,6 +46,9 @@ export function renderDeckBuilder(container, { state, allCards, onChange }) {
       if (card.type === 'hero') {
         state.hero = card;
       } else if (state.cards.length < 60) {
+        if (card.type === 'quest' && state.cards.some(c => c.type === 'quest')) {
+          return;
+        }
         state.cards.push(card);
       }
       // Ask the host to update surrounding UI (buttons, etc.)

--- a/src/js/utils/deckbuilder.js
+++ b/src/js/utils/deckbuilder.js
@@ -8,14 +8,32 @@ export function fillDeckRandomly(state, allCards, rng = null) {
   const pick = rng instanceof RNG ? (arr) => rng.pick(arr) : (arr) => defaultPick(arr);
 
   const heroes = allCards.filter(c => c.type === 'hero');
-  const nonHeroes = allCards.filter(c => c.type !== 'hero');
+  const quests = allCards.filter(c => c.type === 'quest');
+  const others = allCards.filter(c => c.type !== 'hero' && c.type !== 'quest');
+
   if (!state.hero) {
     if (heroes.length === 0) return state;
     state.hero = pick(heroes);
   }
-  while (state.cards.length < 60 && nonHeroes.length > 0) {
-    state.cards.push(pick(nonHeroes));
+
+  // ensure at most one quest is present in the deck state
+  let questSeen = false;
+  for (let i = state.cards.length - 1; i >= 0; i--) {
+    const card = state.cards[i];
+    if (card.type === 'quest') {
+      if (questSeen) state.cards.splice(i, 1);
+      else questSeen = true;
+    }
   }
+
+  while (state.cards.length < 60) {
+    const pool = questSeen ? others : others.concat(quests);
+    if (pool.length === 0) break;
+    const card = pick(pool);
+    state.cards.push(card);
+    if (card.type === 'quest') questSeen = true;
+  }
+
   if (state.cards.length > 60) state.cards.length = 60;
   return state;
 }


### PR DESCRIPTION
## Summary
- ensure random deck filler keeps at most one quest
- block adding additional quests in deck builder UI
- test quest limits for random fill and deck builder

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8213d7bd48323a558d5d8488d3d16