### PR TITLE
feat: add Darnassian Huntress beast targeting

### DIFF
--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -388,6 +388,16 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         expect(unit.data.attack).toBe(before + effect.attack);
         break;
       }
+      case 'buffBeast': {
+        const beast = new Card({ name: 'Beast', type: 'ally', data: { attack: 1, health: 1 }, keywords: ['Beast'] });
+        g.player.battlefield.add(beast);
+        g.promptTarget = async () => beast;
+        await g.playFromHand(g.player, card.id);
+        if (effect.attack) expect(beast.data.attack).toBe(1 + effect.attack);
+        if (effect.health) expect(beast.data.health).toBe(1 + effect.health);
+        if (effect.keywords?.includes('Rush')) expect(beast.keywords).toContain('Rush');
+        break;
+      }
       default:
         throw new Error('Unhandled effect type: ' + effect.type);
     }

--- a/__tests__/darnassian-huntress.targeting.test.js
+++ b/__tests__/darnassian-huntress.targeting.test.js
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('Darnassian Huntress prompts for beast target and buffs it', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+
+  const friendlyBeast = new Card({ name: 'Friendly Beast', type: 'ally', data: { attack: 2, health: 2 }, keywords: ['Beast'] });
+  const enemyBeast = new Card({ name: 'Enemy Beast', type: 'ally', data: { attack: 1, health: 3 }, keywords: ['Beast'] });
+  const nonBeast = new Card({ name: 'Non Beast', type: 'ally', data: { attack: 1, health: 1 }, keywords: [] });
+  g.player.battlefield.add(friendlyBeast);
+  g.player.battlefield.add(nonBeast);
+  g.opponent.battlefield.add(enemyBeast);
+
+  g.addCardToHand('ally-darnassian-huntress');
+  const huntress = g.player.hand.cards.find(c => c.id === 'ally-darnassian-huntress');
+
+  const promptSpy = jest.fn(async candidates => {
+    expect(candidates).toContain(friendlyBeast);
+    expect(candidates).toContain(enemyBeast);
+    expect(candidates).not.toContain(nonBeast);
+    return enemyBeast;
+  });
+  g.promptTarget = promptSpy;
+
+  await g.playFromHand(g.player, huntress.id);
+
+  expect(promptSpy).toHaveBeenCalled();
+  expect(enemyBeast.data.attack).toBe(2); // 1 + 1
+  expect(enemyBeast.data.health).toBe(4); // 3 + 1
+  expect(enemyBeast.keywords).toContain('Rush');
+});

--- a/data/ally.json
+++ b/data/ally.json
@@ -126,8 +126,11 @@
     "cost": 3,
     "effects": [
       {
-        "type": "rawText",
-        "text": "Battlecry — Give a Beast +1/+1 and Rush this turn."
+        "type": "buffBeast",
+        "attack": 1,
+        "health": 1,
+        "keywords": ["Rush"],
+        "duration": "thisTurn"
       }
     ],
     "keywords": [


### PR DESCRIPTION
## Summary
- add generic `buffBeast` effect to handle beast-targeting buffs
- wire Darnassian Huntress to prompt for beasts and grant +1/+1 and Rush
- test Darnassian Huntress battlecry and update effect coverage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c82ba233e88323af2207994faaa82c