### PR TITLE
feat: add model arg to eval script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Developer Notes
   - Browser entry: `src/js/main.js`
 - Tests: `__tests__/*`, run with `npm test` or `npm run test:coverage`.
 - Train Nightmare AI: `npm run train -- <population> <generations> <reset>` — evolutionary RL saves best model to `data/model.json`. Example: `npm run train -- 200 15 true`.
-- Evaluate NN vs hard MCTS: `npm run eval` — runs a single game with NN as player vs hard MCTS as opponent (max 20 rounds) and prints result summary.
+- Evaluate NN vs hard MCTS: `npm run eval` — runs a single game with NN as player vs hard MCTS as opponent (max 20 rounds) and prints result summary. Provide a model path to pit two neural AIs: `npm run eval -- data/other-model.json`.
 - Simulation CLI: `npm run simulate` (quick AI turns). Balance sampling: `node tools/balance.mjs`.
 - Content pipeline: `node tools/cards-ingest.mjs` parses `CARDS.md` and writes per-type JSON under `data/` (e.g., `data/hero.json`, `data/spell.json`, `data/ally.json`, etc.).
 - Live reload policy: `live-reload.json` must be committed; never add to `.gitignore`.

--- a/tools/eval.mjs
+++ b/tools/eval.mjs
@@ -1,23 +1,26 @@
 #!/usr/bin/env node
-// Evaluate a single full game: NN (player) vs hard MCTS (opponent)
+// Evaluate a single full game.
+// Default: NN (player) vs hard MCTS (opponent).
+// If a model path argument is provided, pits NN-best (player) vs NN-candidate (opponent).
 // Caps at 20 rounds (player+opponent turns). Prints concise results.
 
 import Game from '../src/js/game.js';
 import MCTS_AI from '../src/js/systems/ai-mcts.js';
 import NeuralAI, { loadModelFromDiskOrFetch, setActiveModel } from '../src/js/systems/ai-nn.js';
+import MLP from '../src/js/systems/nn.js';
 import { RNG } from '../src/js/utils/rng.js';
 import { getOriginalConsole } from '../src/js/utils/logger.js';
 
-function fmtResult({ rounds, pHP, pArmor, oHP, oArmor }) {
+function fmtResult({ rounds, pHP, pArmor, oHP, oArmor }, pName, oName) {
   const pAlive = pHP > 0;
   const oAlive = oHP > 0;
   let winner = 'draw';
-  if (pAlive && !oAlive) winner = 'NN (player)';
-  else if (!pAlive && oAlive) winner = 'MCTS-hard (opponent)';
+  if (pAlive && !oAlive) winner = `${pName} (player)`;
+  else if (!pAlive && oAlive) winner = `${oName} (opponent)`;
   else if (pAlive && oAlive) {
     const diff = (pHP + pArmor) - (oHP + oArmor);
-    if (diff > 0) winner = 'NN (player) — HP advantage';
-    else if (diff < 0) winner = 'MCTS-hard (opponent) — HP advantage';
+    if (diff > 0) winner = `${pName} (player) — HP advantage`;
+    else if (diff < 0) winner = `${oName} (opponent) — HP advantage`;
   }
   return { winner, rounds, player: { hp: pHP, armor: pArmor }, opponent: { hp: oHP, armor: oArmor } };
 }
@@ -27,6 +30,7 @@ async function main() {
   const argSeed = process.env.SEED || process.argv.find(a => a.startsWith('--seed='))?.split('=')[1];
   const seed = argSeed ? Number(argSeed) >>> 0 : (Math.floor(Math.random() * 0xFFFFFFFF) >>> 0);
   const maxRounds = Number(process.env.MAX_ROUNDS || 20);
+  const modelArg = process.argv.slice(2).find(a => !a.startsWith('--'));
 
   const game = new Game(null);
   game.rng = new RNG(seed);
@@ -37,7 +41,23 @@ async function main() {
   setActiveModel(model);
 
   const nn = new NeuralAI({ game, resourceSystem: game.resources, combatSystem: game.combat, model });
-  const mcts = new MCTS_AI({ resourceSystem: game.resources, combatSystem: game.combat, game, iterations: 5000, rolloutDepth: 10, fullSim: true });
+  let opponentAI = null;
+  let playerName = 'NN';
+  let opponentName = 'MCTS-hard';
+
+  if (modelArg) {
+    const fs = await import('fs/promises');
+    const url = new URL(`../${modelArg}`, import.meta.url);
+    const txt = await fs.readFile(url, 'utf8');
+    const obj = JSON.parse(txt);
+    const oppModel = MLP.fromJSON(obj);
+    opponentAI = new NeuralAI({ game, resourceSystem: game.resources, combatSystem: game.combat, model: oppModel });
+    playerName = 'NN-best';
+    opponentName = 'NN-candidate';
+  } else {
+    opponentAI = new MCTS_AI({ resourceSystem: game.resources, combatSystem: game.combat, game, iterations: 5000, rolloutDepth: 10, fullSim: true });
+  }
+
   const out = getOriginalConsole().log;
 
   let rounds = 0;
@@ -46,18 +66,18 @@ async function main() {
     await nn.takeTurn(game.player, game.opponent);
     if (game.opponent.hero.data.health <= 0 || game.player.hero.data.health <= 0) break;
 
-    // Opponent (MCTS hard) turn
+    // Opponent turn
     game.turns.setActivePlayer(game.opponent);
     game.turns.startTurn();
-    game.resources.startTurn(game.opponent);
-    await mcts.takeTurn(game.opponent, game.player);
+    if (!modelArg) game.resources.startTurn(game.opponent);
+    await opponentAI.takeTurn(game.opponent, game.player);
 
     // End of opponent turn -> advance to player's next turn
     while (game.turns.current !== 'End') game.turns.nextPhase();
     game.turns.nextPhase();
     game.turns.setActivePlayer(game.player);
     game.turns.startTurn();
-    game.resources.startTurn(game.player);
+    if (!modelArg) game.resources.startTurn(game.player);
 
     rounds++;
 
@@ -65,14 +85,14 @@ async function main() {
     const pRoundArmor = game.player.hero.data.armor || 0;
     const oRoundHP = game.opponent.hero.data.health;
     const oRoundArmor = game.opponent.hero.data.armor || 0;
-    out(`[eval] Round ${rounds}: NN HP=${pRoundHP} Armor=${pRoundArmor} | MCTS-hard HP=${oRoundHP} Armor=${oRoundArmor}`);
+    out(`[eval] Round ${rounds}: ${playerName} HP=${pRoundHP} Armor=${pRoundArmor} | ${opponentName} HP=${oRoundHP} Armor=${oRoundArmor}`);
   }
 
   const pHP = game.player.hero.data.health;
   const pArmor = game.player.hero.data.armor || 0;
   const oHP = game.opponent.hero.data.health;
   const oArmor = game.opponent.hero.data.armor || 0;
-  const summary = fmtResult({ rounds, pHP, pArmor, oHP, oArmor });
+  const summary = fmtResult({ rounds, pHP, pArmor, oHP, oArmor }, playerName, opponentName);
 
   // Basic action counts for color
   const pPlays = game.player.log.filter(l => l.startsWith('Played ')).length;
@@ -81,8 +101,8 @@ async function main() {
   // Always print via original console to bypass debug silencing
   out(`[eval] Seed=0x${seed.toString(16)} rounds=${summary.rounds}`);
   out(`[eval] Result: ${summary.winner}`);
-  out(`[eval] Player (NN) HP=${pHP} Armor=${pArmor} | Plays=${pPlays}`);
-  out(`[eval] Opponent (MCTS-hard) HP=${oHP} Armor=${oArmor} | Plays=${oPlays}`);
+  out(`[eval] Player (${playerName}) HP=${pHP} Armor=${pArmor} | Plays=${pPlays}`);
+  out(`[eval] Opponent (${opponentName}) HP=${oHP} Armor=${oArmor} | Plays=${oPlays}`);
 }
 
 main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- allow `npm run eval` to accept a model path and pit two neural AIs when provided
- document eval model argument in README

## Testing
- `npm test`
- `npm run lint`
- `MAX_ROUNDS=1 node tools/eval.mjs data/model.json`
- `MAX_ROUNDS=1 node tools/eval.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68c82fd40a888323b0fc554c8443ab8e