### PR TITLE
feat: support training against saved model baseline

### DIFF
--- a/__tests__/tools.train.args.test.js
+++ b/__tests__/tools.train.args.test.js
@@ -4,19 +4,25 @@ describe('parseTrainArgs', () => {
   test('defaults when no args provided', () => {
     const args = ['node', 'tools/train.mjs'];
     const res = parseTrainArgs(args);
-    expect(res).toEqual({ pop: 100, gens: 10, reset: false });
+    expect(res).toEqual({ pop: 100, gens: 10, reset: false, opponent: 'mcts' });
   });
 
   test('parses population, generations, and reset=true', () => {
     const args = ['node', 'tools/train.mjs', '250', '20', 'true'];
     const res = parseTrainArgs(args);
-    expect(res).toEqual({ pop: 250, gens: 20, reset: true });
+    expect(res).toEqual({ pop: 250, gens: 20, reset: true, opponent: 'mcts' });
   });
 
   test('handles reset falsy variations', () => {
     const args = ['node', 'tools/train.mjs', '150', '5', 'false'];
     const res = parseTrainArgs(args);
-    expect(res).toEqual({ pop: 150, gens: 5, reset: false });
+    expect(res).toEqual({ pop: 150, gens: 5, reset: false, opponent: 'mcts' });
+  });
+
+  test('parses opponent flag for saved model baseline', () => {
+    const args = ['node', 'tools/train.mjs', '50', '10', 'true', 'false'];
+    const res = parseTrainArgs(args);
+    expect(res).toEqual({ pop: 50, gens: 10, reset: true, opponent: 'best' });
   });
 });
 

--- a/tools/train.args.mjs
+++ b/tools/train.args.mjs
@@ -1,11 +1,12 @@
 // Argument parsing for tools/train.mjs
-// Usage: npm run train -- <population> <generations> <reset>
+// Usage: npm run train -- <population> <generations> <reset> <useMctsOpponent>
 // - population: integer (default 100)
 // - generations: integer (default 10)
 // - reset: true/false/1/0/yes/no (default false)
+// - useMctsOpponent: true/false/mcts/best (default true => hard MCTS; false => saved NN opponent)
 
 export function parseTrainArgs(argv = process.argv) {
-  const [, , popArg, genArg, resetArg] = argv;
+  const [, , popArg, genArg, resetArg, opponentArg] = argv;
 
   const toInt = (v) => {
     const n = Number.parseInt(v, 10);
@@ -15,11 +16,19 @@ export function parseTrainArgs(argv = process.argv) {
     if (typeof v !== 'string') return false;
     return /^(true|1|yes|y)$/i.test(v);
   };
+  const parseOpponent = (v) => {
+    if (v == null) return 'mcts';
+    const text = String(v).trim().toLowerCase();
+    if (/^(true|1|yes|y|mcts|baseline|default)$/.test(text)) return 'mcts';
+    if (/^(false|0|no|n|best|prev|previous|nn|model)$/.test(text)) return 'best';
+    return 'mcts';
+  };
 
   const pop = toInt(popArg) ?? 100;
   const gens = toInt(genArg) ?? 10;
   const reset = toBool(resetArg);
+  const opponent = parseOpponent(opponentArg);
 
-  return { pop, gens, reset };
+  return { pop, gens, reset, opponent };
 }
 


### PR DESCRIPTION
## Summary
- add a CLI flag that lets `npm run train` evaluate against either the default MCTS baseline or the saved neural net model
- update the training pipeline to load the previous best model as the opponent when requested and fall back to MCTS if missing
- extend the train argument unit tests to cover the new opponent selection behaviour

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8894f3de483238b16fea4737ceaa5