### PR TITLE
fix: ensure AI decks exclude quests

### DIFF
--- a/__tests__/game.cards.test.js
+++ b/__tests__/game.cards.test.js
@@ -7,26 +7,67 @@ test('setupMatch creates a 60 card library', async () => {
   expect(g.opponent.library.cards.length + g.opponent.hand.cards.length).toBe(60);
 });
 
-  test('setupMatch assigns different heroes to players', async () => {
-    const g = new Game();
-    await g.setupMatch();
-    expect(g.player.hero).toBeDefined();
-    expect(g.opponent.hero).toBeDefined();
-    expect(g.player.hero.id).not.toBe(g.opponent.hero.id);
-  });
+test('setupMatch assigns different heroes to players', async () => {
+  const g = new Game();
+  await g.setupMatch();
+  expect(g.player.hero).toBeDefined();
+  expect(g.opponent.hero).toBeDefined();
+  expect(g.player.hero.id).not.toBe(g.opponent.hero.id);
+});
 
-  test('cards loaded with text for tooltips', async () => {
-    const g = new Game();
-    await g.setupMatch();
-    const hasText = g.allCards.every(c => typeof c.text === 'string');
-    expect(hasText).toBe(true);
-  });
+test('cards loaded with text for tooltips', async () => {
+  const g = new Game();
+  await g.setupMatch();
+  const hasText = g.allCards.every(c => typeof c.text === 'string');
+  expect(hasText).toBe(true);
+});
 
-  test('players draw a card at the start of their turn', async () => {
-    const g = new Game();
-    await g.setupMatch();
-    expect(g.player.hand.size()).toBe(4);
-    const before = g.player.hand.size();
-    g.turns.startTurn();
-    expect(g.player.hand.size()).toBe(before + 1);
-  });
+test('players draw a card at the start of their turn', async () => {
+  const g = new Game();
+  await g.setupMatch();
+  expect(g.player.hand.size()).toBe(4);
+  const before = g.player.hand.size();
+  g.turns.startTurn();
+  expect(g.player.hand.size()).toBe(before + 1);
+});
+
+test('AI decks exclude quest cards by default', async () => {
+  const g = new Game();
+  await g.setupMatch();
+  expect(g.allCards.some(c => c.type === 'quest')).toBe(true);
+  const playerZones = [...g.player.library.cards, ...g.player.hand.cards];
+  const opponentZones = [...g.opponent.library.cards, ...g.opponent.hand.cards];
+  expect(playerZones.every(c => c.type !== 'quest')).toBe(true);
+  expect(opponentZones.every(c => c.type !== 'quest')).toBe(true);
+});
+
+test('human decks retain quests when player is not AI', async () => {
+  const g = new Game(null, { aiPlayers: ['opponent'] });
+  await g.setupMatch();
+  const hero = g.allCards.find(c => c.type === 'hero');
+  const quest = g.allCards.find(c => c.type === 'quest');
+  const filler = g.allCards.find(c => c.type !== 'hero' && c.type !== 'quest');
+  expect(hero).toBeTruthy();
+  expect(quest).toBeTruthy();
+  expect(filler).toBeTruthy();
+  const cards = [quest, ...Array(59).fill(filler)];
+  await g.setupMatch({ hero, cards });
+  const playerZones = [...g.player.library.cards, ...g.player.hand.cards];
+  expect(playerZones.filter(c => c.type === 'quest')).toHaveLength(1);
+});
+
+test('AI provided decks strip quests for the player', async () => {
+  const g = new Game(null, { aiPlayers: ['player', 'opponent'] });
+  await g.setupMatch();
+  const hero = g.allCards.find(c => c.type === 'hero');
+  const quest = g.allCards.find(c => c.type === 'quest');
+  const filler = g.allCards.find(c => c.type !== 'hero' && c.type !== 'quest');
+  expect(hero).toBeTruthy();
+  expect(quest).toBeTruthy();
+  expect(filler).toBeTruthy();
+  const cards = [quest, ...Array(59).fill(filler)];
+  await g.setupMatch({ hero, cards });
+  const playerZones = [...g.player.library.cards, ...g.player.hand.cards];
+  expect(playerZones.every(c => c.type !== 'quest')).toBe(true);
+  expect(playerZones.length).toBe(60);
+});

--- a/tools/eval.mjs
+++ b/tools/eval.mjs
@@ -32,7 +32,7 @@ async function main() {
   const maxRounds = Number(process.env.MAX_ROUNDS || 20);
   const modelArg = process.argv.slice(2).find(a => !a.startsWith('--'));
 
-  const game = new Game(null);
+  const game = new Game(null, { aiPlayers: ['player', 'opponent'] });
   game.rng = new RNG(seed);
   await game.setupMatch();
 

--- a/tools/train.mjs
+++ b/tools/train.mjs
@@ -73,7 +73,7 @@ async function evalCandidate(model, { games = 5, maxRounds = 20, opponentMode = 
     : null;
   let total = 0;
   for (let g = 0; g < games; g++) {
-    const game = new Game(null);
+    const game = new Game(null, { aiPlayers: ['player', 'opponent'] });
     // Randomize RNG seed per evaluation to diversify decks/hands
     const seed = (Math.floor(Math.random() * 0xFFFFFFFF)) >>> 0;
     game.rng = new RNG(seed);

--- a/tools/train.worker.mjs
+++ b/tools/train.worker.mjs
@@ -17,7 +17,7 @@ async function evalCandidate(model, { games = 5, maxRounds = 20, opponentMode = 
     : null;
   let total = 0;
   for (let g = 0; g < games; g++) {
-    const game = new Game(null);
+    const game = new Game(null, { aiPlayers: ['player', 'opponent'] });
     // Randomize RNG seed per evaluation to diversify matchups
     const seed = (Math.floor(Math.random() * 0xFFFFFFFF)) >>> 0;
     game.rng = new RNG(seed);


### PR DESCRIPTION
## Summary
- teach the Game to track which seats are AI-controlled and build their libraries from a non-quest pool
- prevent quests from entering AI decks even when a custom list is provided, while keeping human decks unchanged
- add regression tests for the new behavior and update training/evaluation scripts to request AI-safe decks

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c90f6a01e083239bcf9f37b369b804