### PR TITLE
fix: sync divine shield keyword with state

### DIFF
--- a/__tests__/divine-shield.test.js
+++ b/__tests__/divine-shield.test.js
@@ -17,6 +17,7 @@ describe('Divine Shield', () => {
     await g.effects.dealDamage({ target: 'minion', amount: 5 }, { game: g, player: p, card: null });
     expect(target.data.health).toBe(3);
     expect(target.data.divineShield).toBe(false);
+    expect(target.keywords?.includes('Divine Shield')).toBe(false);
 
     // Next damage reduces health normally
     await g.effects.dealDamage({ target: 'minion', amount: 2 }, { game: g, player: p, card: null });
@@ -36,6 +37,7 @@ describe('Divine Shield', () => {
     // First strike: shield consumed, no health loss
     expect(defender.data.divineShield).toBe(false);
     expect(defender.data.health).toBe(5);
+    expect(defender.keywords?.includes('Divine Shield')).toBe(false);
 
     // Second strike applies damage
     c.declareAttacker(attacker);

--- a/src/js/systems/combat.js
+++ b/src/js/systems/combat.js
@@ -172,6 +172,9 @@ export class CombatSystem {
       const shielded = !!(ev.target?.data?.divineShield);
       if (shielded) {
         ev.target.data.divineShield = false;
+        if (ev.target?.keywords?.includes?.('Divine Shield')) {
+          ev.target.keywords = ev.target.keywords.filter(k => k !== 'Divine Shield');
+        }
         ev.amount = 0;
         // No damage applied; skip armor, logging, freeze, and death marking
         continue;

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -288,6 +288,9 @@ export class EffectSystem {
       // Divine Shield absorbs one instance of damage (for shielded minions)
       if (t?.data?.divineShield) {
         t.data.divineShield = false;
+        if (t?.keywords?.includes?.('Divine Shield')) {
+          t.keywords = t.keywords.filter(k => k !== 'Divine Shield');
+        }
         // Emit zero-damage event for consistency with combat events
         game.bus.emit('damageDealt', { player, source: card, amount: 0, target: t });
         continue;


### PR DESCRIPTION
## Summary
- remove the Divine Shield keyword from cards when the shield is consumed during combat or direct damage resolution
- keep spell and combat logic aligned so AI scoring and tooltips reflect the current keyword state
- extend Divine Shield tests to assert keyword removal once the shield breaks

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c936511e4c832382a3ae1541582648