### PR TITLE
Add spell damage coverage for Thrall hero power

### DIFF
--- a/__tests__/thrall.hero-power.test.js
+++ b/__tests__/thrall.hero-power.test.js
@@ -1,9 +1,12 @@
 import fs from 'fs';
 import Game from '../src/js/game.js';
 import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
 
-const cards = JSON.parse(fs.readFileSync(new URL('../data/cards/hero.json', import.meta.url)));
-const thrallData = cards.find(c => c.id === 'hero-thrall-warchief-of-the-horde');
+const heroCards = JSON.parse(fs.readFileSync(new URL('../data/cards/hero.json', import.meta.url)));
+const thrallData = heroCards.find(c => c.id === 'hero-thrall-warchief-of-the-horde');
+const allyCards = JSON.parse(fs.readFileSync(new URL('../data/cards/ally.json', import.meta.url)));
+const dalaranEvokerData = allyCards.find(c => c.id === 'ally-dalaran-evoker');
 
 test("Thrall's hero power applies Overload 1", async () => {
   const g = new Game();
@@ -18,4 +21,42 @@ test("Thrall's hero power applies Overload 1", async () => {
   g.turns.turn = 3;
   g.resources.startTurn(g.player);
   expect(g.resources.pool(g.player)).toBe(2);
+});
+
+test("Thrall's hero power gains Spell Damage from Dalaran Evoker", async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hero = new Hero(thrallData);
+  g.player.hero.owner = g.player;
+
+  const evoker = new Card(dalaranEvokerData);
+  evoker.owner = g.player;
+  g.player.battlefield.add(evoker);
+
+  g.opponent.hero.data.armor = 0;
+  const firstTarget = new Card({ name: 'Target Dummy A', type: 'ally', data: { attack: 0, health: 3 } });
+  const secondTarget = new Card({ name: 'Target Dummy B', type: 'ally', data: { attack: 0, health: 3 } });
+  firstTarget.owner = g.opponent;
+  secondTarget.owner = g.opponent;
+  g.opponent.battlefield.add(firstTarget);
+  g.opponent.battlefield.add(secondTarget);
+
+  const enemyHeroStart = g.opponent.hero.data.health;
+  const firstStart = firstTarget.data.health;
+  const secondStart = secondTarget.data.health;
+
+  const picks = [g.opponent.hero, firstTarget, secondTarget];
+  let pickIndex = 0;
+  g.promptTarget = async () => picks[pickIndex++] ?? null;
+
+  g.turns.turn = 2;
+  g.resources.startTurn(g.player);
+  g.turns.setActivePlayer(g.player);
+
+  await g.useHeroPower(g.player);
+
+  expect(g.opponent.hero.data.health).toBe(enemyHeroStart - 2);
+  expect(firstTarget.data.health).toBe(firstStart - 2);
+  expect(secondTarget.data.health).toBe(secondStart - 2);
 });

--- a/data/cards/hero.json
+++ b/data/cards/hero.json
@@ -27,7 +27,8 @@
       {
         "type": "damage",
         "target": "upToThreeTargets",
-        "amount": 1
+        "amount": 1,
+        "usesSpellDamage": true
       },
       {
         "type": "overload",


### PR DESCRIPTION
## Summary
- ensure Thrall's Chain Spark hero power applies spell damage bonuses
- add a regression test covering the Dalaran Evoker interaction

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9726e06148323a89e7fbc3ce99a31