### PR TITLE
feat: reward quicker neural wins during training

### DIFF
--- a/tools/train.mjs
+++ b/tools/train.mjs
@@ -89,6 +89,7 @@ async function evalCandidate(model, { games = 5, maxRounds = 20, opponentMode = 
 
     // Ensure start is player's turn (Game.setupMatch sets player start)
     let rounds = 0;
+    let opponentTurns = 0;
     while (rounds < maxRounds && game.player.hero.data.health > 0 && game.opponent.hero.data.health > 0) {
       // Player turn
       await playerAI.takeTurn(game.player, game.opponent);
@@ -99,6 +100,7 @@ async function evalCandidate(model, { games = 5, maxRounds = 20, opponentMode = 
       game.turns.startTurn();
       game.resources.startTurn(game.opponent);
       await aiOpp.takeTurn(game.opponent, game.player);
+      opponentTurns++;
 
       // End of opponent turn -> advance to player's next turn
       while (game.turns.current !== 'End') game.turns.nextPhase();
@@ -115,7 +117,12 @@ async function evalCandidate(model, { games = 5, maxRounds = 20, opponentMode = 
     const neuralLost = (eHP <= 0 && pHP > 0);
     // Fitness: reward win highly, loss low, draws/unfinished by HP differential
     const hpDiff = (eHP - pHP) / 40; // positive favors opponent (neural)
-    if (neuralWon) total += 2.0;
+    if (neuralWon) {
+      const turnsUsed = opponentTurns > 0 ? opponentTurns : rounds;
+      const maxTurns = Math.max(1, maxRounds);
+      const speedBonus = Math.max(0, (maxRounds - turnsUsed) / maxTurns);
+      total += 2.0 + speedBonus;
+    }
     else if (neuralLost) total += 0.0;
     else total += 0.5 + hpDiff;
   }


### PR DESCRIPTION
## Summary
- track opponent turns during training evaluations
- award a speed bonus when the neural AI wins in fewer turns
- mirror the updated scoring in the worker evaluator

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c98459283c8323aead42a6ac8b78c6