### PR TITLE
feat: log secret triggers in combat log

### DIFF
--- a/__tests__/game.playFromHand.test.js
+++ b/__tests__/game.playFromHand.test.js
@@ -10,3 +10,27 @@ test('playing an ally moves it from hand to battlefield', async () => {
   expect(g.player.battlefield.cards).toContain(ally);
   expect(g.player.hand.cards).not.toContain(ally);
 });
+
+test('counter secret writes combat log entries when triggered', async () => {
+  const g = new Game();
+  const counterShot = new Card({
+    type: 'spell',
+    name: 'Counter Shot',
+    cost: 0,
+    effects: [{ type: 'counterShot' }],
+  });
+
+  await g.effects.execute(counterShot.effects, { game: g, player: g.opponent, card: counterShot });
+
+  g.resources._pool.set(g.player, 10);
+  g.resources._pool.set(g.opponent, 10);
+
+  const spell = new Card({ type: 'spell', name: 'Arcane Blast', cost: 1 });
+  g.player.hand.add(spell);
+
+  const played = await g.playFromHand(g.player, spell.id);
+
+  expect(played).toBe(true);
+  expect(g.opponent.log).toContain('Secret triggered: Counter Shot');
+  expect(g.player.log).toContain('Enemy secret triggered: Counter Shot');
+});

--- a/__tests__/systems.effects.test.js
+++ b/__tests__/systems.effects.test.js
@@ -112,6 +112,9 @@ describe('EffectSystem', () => {
     await game.effects.dealDamage({ target: 'selfHero', amount: 1 }, { game, player, card: null });
     await new Promise(r => setTimeout(r, 0));
 
+    expect(player.log).toContain('Secret triggered: Explosive Trap');
+    expect(opponent.log).toContain('Enemy secret triggered: Explosive Trap');
+
     expect(player.hero.data.health).toBe(7);
     expect(opponent.hero.data.health).toBe(8);
     expect(ally.data.health).toBe(1);

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -1,6 +1,7 @@
 import Card from '../entities/card.js';
 import Equipment from '../entities/equipment.js';
 import { rememberSecretToken, enrichSecretToken } from '../utils/savegame.js';
+import { logSecretTriggered } from '../utils/combatLog.js';
 import { freezeTarget, getSpellDamageBonus, computeSpellDamage, isTargetable } from './keywords.js';
 import { selectTargets } from './targeting.js';
 
@@ -492,6 +493,7 @@ export class EffectSystem {
     const handler = async ({ target }) => {
       if (target !== player.hero) return;
       off();
+      logSecretTriggered(game, player, { card, token });
       // Remove the secret indicator when it triggers
       const arr = player.hero?.data?.secrets;
       if (Array.isArray(arr)) {
@@ -547,6 +549,7 @@ export class EffectSystem {
 
       // Secret triggers once
       off();
+      logSecretTriggered(game, player, { card, token });
       // Remove the secret indicator when it triggers
       const arr = player.hero?.data?.secrets;
       if (Array.isArray(arr)) {
@@ -586,6 +589,7 @@ export class EffectSystem {
       const isEnemy = opponent.battlefield.cards.includes(attacker) || attacker === opponent.hero;
       if (!isEnemy) return;
       off();
+      logSecretTriggered(game, player, { card, token });
       // Remove the secret indicator when it triggers
       const arr = player.hero?.data?.secrets;
       if (Array.isArray(arr)) {
@@ -645,6 +649,7 @@ export class EffectSystem {
       if (!isFriendlyTarget || !fromOpponent) return;
 
       off();
+      logSecretTriggered(game, player, { card, token });
       // Remove secret indicator
       const arr = player.hero?.data?.secrets;
       if (Array.isArray(arr)) {
@@ -698,6 +703,7 @@ export class EffectSystem {
       if (killer !== opponent) return;
 
       off();
+      logSecretTriggered(game, player, { card, token });
       // Remove secret indicator
       const arr = player.hero?.data?.secrets;
       if (Array.isArray(arr)) {

--- a/src/js/utils/combatLog.js
+++ b/src/js/utils/combatLog.js
@@ -1,0 +1,29 @@
+const SECRET_FALLBACK = 'Secret';
+
+function formatSecretName(card, token) {
+  if (card?.name) return card.name;
+  const type = token?.type || token?.effect?.type;
+  if (!type) return SECRET_FALLBACK;
+  const normalized = String(type)
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim();
+  if (!normalized) return SECRET_FALLBACK;
+  return normalized
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function logSecretTriggered(game, owner, { card = null, token = null } = {}) {
+  if (!game || !owner) return;
+  const secretName = formatSecretName(card, token);
+  if (Array.isArray(owner.log)) owner.log.push(`Secret triggered: ${secretName}`);
+  const opponent = owner === game.player ? game.opponent : game.player;
+  if (opponent && Array.isArray(opponent.log)) {
+    opponent.log.push(`Enemy secret triggered: ${secretName}`);
+  }
+}
+
+export default logSecretTriggered;


### PR DESCRIPTION
## Summary
- add a shared helper to format secret names and push combat log messages
- invoke the helper from secret effects and counter resolution so triggers are recorded
- cover the new behaviour with explosive trap and counter shot tests

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c99d64828c83239833b0c901127510