### PR TITLE
fix: use seeded RNG for deck shuffles

### DIFF
--- a/__tests__/deck.shuffle.test.js
+++ b/__tests__/deck.shuffle.test.js
@@ -1,0 +1,21 @@
+import Deck from '../src/js/entities/deck.js';
+import { RNG } from '../src/js/utils/rng.js';
+
+describe('Deck.shuffle', () => {
+  it('uses provided RNG instances for deterministic shuffles', () => {
+    const cards = Array.from({ length: 10 }, (_, i) => ({ id: `card-${i}` }));
+    const deckA = new Deck();
+    deckA.cards = cards.map(card => ({ ...card }));
+    const deckB = new Deck();
+    deckB.cards = cards.map(card => ({ ...card }));
+
+    const seed = 0x1A2B3C4D;
+    const rngA = new RNG(seed);
+    const rngB = new RNG(seed);
+
+    deckA.shuffle(rngA);
+    deckB.shuffle(rngB);
+
+    expect(deckA.cards.map(c => c.id)).toEqual(deckB.cards.map(c => c.id));
+  });
+});

--- a/src/js/entities/deck.js
+++ b/src/js/entities/deck.js
@@ -4,8 +4,17 @@ import { RNG } from '../utils/rng.js';
 export class Deck extends Zone {
   constructor(name = 'deck') { super(name); }
 
-  shuffle(seed = Date.now()) {
-    const r = new RNG(seed);
+  shuffle(seedOrRng) {
+    let r;
+    if (seedOrRng instanceof RNG) {
+      r = seedOrRng;
+    } else if (seedOrRng && typeof seedOrRng.randomInt === 'function') {
+      r = seedOrRng;
+    } else if (typeof seedOrRng === 'number') {
+      r = new RNG(seedOrRng);
+    } else {
+      r = new RNG(Date.now());
+    }
     // Fisher–Yates in place
     for (let i = this.cards.length - 1; i > 0; i--) {
       const j = r.randomInt(0, i + 1);

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -205,8 +205,8 @@ export default class Game {
       this.opponent.library.add(new Card(cardData));
     }
 
-    this.player.library.shuffle();
-    this.opponent.library.shuffle();
+    this.player.library.shuffle(rng);
+    this.opponent.library.shuffle(rng);
 
     
 


### PR DESCRIPTION
## Summary
- allow `Deck.shuffle` to reuse a provided RNG instance or seed instead of always deriving from `Date.now`
- pass the game's seeded RNG into player and opponent deck shuffles during match setup
- cover deterministic shuffle behavior with a new Jest test

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9b21ccafc8323854aae54a40fb46a