### PR TITLE
feat: implement Ashkandi taunt aura

### DIFF
--- a/__tests__/ashkandi.taunt-aura.test.js
+++ b/__tests__/ashkandi.taunt-aura.test.js
@@ -1,0 +1,73 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+function createTauntAlly({ id, attack, health }) {
+  return new Card({
+    id,
+    name: `Taunt Ally ${id}`,
+    type: 'ally',
+    cost: 0,
+    data: { attack, health },
+    keywords: ['Taunt']
+  });
+}
+
+test('Ashkandi grants Taunt allies +1 attack while equipped', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+
+  const earlyTaunt = createTauntAlly({ id: 'ally-early-taunt', attack: 2, health: 4 });
+  const nonTaunt = new Card({
+    id: 'ally-non-taunt',
+    name: 'Non-Taunt Ally',
+    type: 'ally',
+    cost: 0,
+    data: { attack: 3, health: 3 },
+    keywords: []
+  });
+
+  g.player.hand.add(earlyTaunt);
+  g.player.hand.add(nonTaunt);
+  await g.playFromHand(g.player, earlyTaunt.id);
+  await g.playFromHand(g.player, nonTaunt.id);
+
+  expect(earlyTaunt.data.attack).toBe(2);
+  expect(nonTaunt.data.attack).toBe(3);
+
+  const ashkandi = new Card({
+    id: 'equipment-ashkandi-greatsword-of-the-brotherhood',
+    name: 'Ashkandi, Greatsword of the Brotherhood',
+    type: 'equipment',
+    cost: 0,
+    attack: 5,
+    durability: 1,
+    effects: [
+      { type: 'equipmentKeywordAura', keyword: 'Taunt', attack: 1 }
+    ],
+  });
+
+  g.player.hand.add(ashkandi);
+  await g.playFromHand(g.player, ashkandi.id);
+
+  expect(earlyTaunt.data.attack).toBe(3);
+  expect(nonTaunt.data.attack).toBe(3);
+
+  const laterTaunt = createTauntAlly({ id: 'ally-later-taunt', attack: 1, health: 2 });
+  g.player.hand.add(laterTaunt);
+  await g.playFromHand(g.player, laterTaunt.id);
+  expect(laterTaunt.data.attack).toBe(2);
+
+  const equipped = g.player.hero.equipment[0];
+  expect(equipped).toBeTruthy();
+  equipped.durability = 0;
+  g.player.hero.equipment = [];
+  g.bus.emit('damageDealt', { player: g.player, source: g.player.hero, amount: 0, target: g.opponent.hero });
+
+  expect(earlyTaunt.data.attack).toBe(2);
+  expect(laterTaunt.data.attack).toBe(1);
+});

--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -328,6 +328,30 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         expect(demon.data.health).toBe(2);
         break;
       }
+      case 'equipmentKeywordAura': {
+        const tauntAlly = new Card({
+          name: 'Taunt Ally',
+          type: 'ally',
+          data: { attack: 2, health: 3 },
+          keywords: [effect.keyword],
+        });
+        const otherAlly = new Card({
+          name: 'Other Ally',
+          type: 'ally',
+          data: { attack: 4, health: 4 },
+          keywords: [],
+        });
+        g.player.battlefield.add(tauntAlly);
+        g.player.battlefield.add(otherAlly);
+        await g.playFromHand(g.player, card.id);
+        const attackBonus = typeof effect.attack === 'number' ? effect.attack : 0;
+        const healthBonus = typeof effect.health === 'number' ? effect.health : 0;
+        expect(tauntAlly.data.attack).toBe(2 + attackBonus);
+        expect(tauntAlly.data.health).toBe(3 + healthBonus);
+        expect(otherAlly.data.attack).toBe(4);
+        expect(otherAlly.data.health).toBe(4);
+        break;
+      }
       case 'buffOnArmorGain': {
         g.player.hand.add(new Card(card));
         const treant = g.player.hand.cards[0];

--- a/data/cards/equipment.json
+++ b/data/cards/equipment.json
@@ -8,8 +8,9 @@
     "durability": 1,
     "effects": [
       {
-        "type": "rawText",
-        "text": "While equipped, your Taunt allies have +1 ATK."
+        "type": "equipmentKeywordAura",
+        "keyword": "Taunt",
+        "attack": 1
       }
     ],
     "keywords": [


### PR DESCRIPTION
## Summary
- add an equipmentKeywordAura effect that applies attack/health auras while the source equipment remains equipped
- update Ashkandi to use the new aura effect so Taunt allies gain +1 attack while it is equipped
- expand automated tests to cover the new aura behavior and ensure the generic effects test handles the effect

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca76c551888323a8b68d8a80692e29