### PR TITLE
fix: resume mcts ai turn after loading

### DIFF
--- a/__tests__/game.mcts.resume.test.js
+++ b/__tests__/game.mcts.resume.test.js
@@ -1,0 +1,83 @@
+import { jest } from '@jest/globals';
+import Game from '../src/js/game.js';
+import { captureGameState, restoreCapturedState } from '../src/js/utils/savegame.js';
+
+async function waitFor(predicate, timeout = 5000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      if (predicate()) return resolve();
+      if (Date.now() - start > timeout) return reject(new Error('Timed out waiting for condition'));
+      setTimeout(check, 0);
+    };
+    check();
+  });
+}
+
+test('resumePendingAITurn resumes a running MCTS turn from a save snapshot', async () => {
+  let game;
+  let resolveTurn;
+  const initialAi = {
+    takeTurn: (_player, _opponent, opts = {}) => {
+      if (game?.state?.aiPending) game.state.aiPending.stage = 'running';
+      return new Promise((resolve) => {
+        resolveTurn = resolve;
+      });
+    }
+  };
+  game = new Game(null, { createMctsAI: async () => initialAi });
+  await game.init();
+  game.state.difficulty = 'medium';
+
+  const turnPromise = game.endTurn();
+  await waitFor(() => game.state?.aiPending?.stage === 'running');
+
+  const snapshot = captureGameState(game);
+  expect(snapshot?.state?.aiPending).toEqual({ type: 'mcts', stage: 'running' });
+
+  resolveTurn();
+  await turnPromise;
+
+  let resumeOpts = null;
+  let clone;
+  const resumeAi = {
+    takeTurn: jest.fn(async (_player, _opponent, opts = {}) => {
+      resumeOpts = opts;
+      if (clone.state?.aiPending) clone.state.aiPending.stage = 'running';
+    })
+  };
+  clone = new Game(null, { createMctsAI: async () => resumeAi });
+  await clone.init();
+  const ok = restoreCapturedState(clone, snapshot);
+  expect(ok).toBe(true);
+  expect(clone.state.aiThinking).toBe(true);
+
+  const resumed = await clone.resumePendingAITurn();
+  expect(resumed).toBe(true);
+  expect(resumeAi.takeTurn).toHaveBeenCalledTimes(1);
+  expect(resumeOpts).toEqual({ resume: true });
+  expect(clone.state.aiThinking).toBe(false);
+  expect(clone.state.aiPending).toBeNull();
+  expect(clone.turns.activePlayer).toBe(clone.player);
+});
+
+test('resumePendingAITurn restarts a queued MCTS turn from save data', async () => {
+  const resumeAi = {
+    takeTurn: jest.fn(async () => {})
+  };
+  const game = new Game(null, { createMctsAI: async () => resumeAi });
+  await game.init();
+  game.state.difficulty = 'medium';
+  game.state.aiThinking = true;
+  game.state.aiPending = { type: 'mcts', stage: 'queued' };
+  game.turns.setActivePlayer(game.opponent);
+  game.turns.current = 'Start';
+
+  const resumed = await game.resumePendingAITurn();
+  expect(resumed).toBe(true);
+  expect(resumeAi.takeTurn).toHaveBeenCalledTimes(1);
+  expect(resumeAi.takeTurn.mock.calls[0][2]).toEqual({ resume: false });
+  expect(game.state.aiThinking).toBe(false);
+  expect(game.state.aiPending).toBeNull();
+  expect(game.turns.activePlayer).toBe(game.player);
+});

--- a/__tests__/utils.savegame.test.js
+++ b/__tests__/utils.savegame.test.js
@@ -10,6 +10,7 @@ describe('savegame utilities', () => {
     // Modify some state to ensure it survives round-trip
     game.player.hero.data.health -= 3;
     game.state.debug = true;
+    game.state.aiPending = { type: 'mcts', stage: 'running' };
     game.turns.turn = 3;
     game.turns.current = 'Main';
     game.resources._pool.set(game.player, 2);
@@ -28,6 +29,7 @@ describe('savegame utilities', () => {
     expect(clone.turns.current).toBe('Main');
     expect(clone.resources.pool(clone.player)).toBe(2);
     expect(clone.state.debug).toBe(true);
+    expect(clone.state.aiPending).toEqual({ type: 'mcts', stage: 'running' });
   });
 
   test('secrets persist across save and restore', async () => {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -31,8 +31,9 @@ try {
   }
 } catch {}
 
+let loadedFromSave = false;
 try {
-  loadSavedGameState(game);
+  loadedFromSave = loadSavedGameState(game);
 } catch {}
 
 // Expose for quick dev console hooks
@@ -79,6 +80,10 @@ game.bus.on('ai:progress', ({ progress }) => {
   if (game.state) game.state.aiProgress = Math.max(0, Math.min(1, progress ?? 0));
   rerender();
 });
+
+if (loadedFromSave && game.state?.aiThinking && game.state?.aiPending?.type === 'mcts') {
+  game.resumePendingAITurn().catch(() => {});
+}
 // Keep UI in sync when quests complete (quest card moves off battlefield)
 game.bus.on('quest:completed', () => {
   rerender();

--- a/src/js/systems/ai-mcts.js
+++ b/src/js/systems/ai-mcts.js
@@ -689,11 +689,17 @@ export class MCTS_AI {
     });
   }
 
-  async takeTurn(player, opponent = null) {
+  async takeTurn(player, opponent = null, options = {}) {
+    const { resume = false } = options;
     // Start turn: mirror BasicAI semantics
-    this.resources.startTurn(player);
-    const drawn = player.library.draw(1);
-    if (drawn[0]) player.hand.add(drawn[0]);
+    if (!resume) {
+      this.resources.startTurn(player);
+      const drawn = player.library.draw(1);
+      if (drawn[0]) player.hand.add(drawn[0]);
+    }
+    if (this.game?.state?.aiPending?.type === 'mcts') {
+      this.game.state.aiPending.stage = 'running';
+    }
 
     // Iteratively choose and apply actions using MCTS until we choose to end
     let powerAvailable = !!(player.hero?.active?.length) && !player.hero.powerUsed;

--- a/src/js/utils/savegame.js
+++ b/src/js/utils/savegame.js
@@ -349,6 +349,9 @@ export function captureGameState(game) {
     debug: !!game.state?.debug,
     aiThinking: !!game.state?.aiThinking,
     aiProgress: game.state?.aiProgress ?? 0,
+    aiPending: game.state?.aiPending
+      ? { type: game.state.aiPending.type || null, stage: game.state.aiPending.stage || 'queued' }
+      : null,
     frame: game.state?.frame ?? 0,
     startedAt: game.state?.startedAt ?? Date.now(),
   };


### PR DESCRIPTION
## Summary
- mark MCTS turns as pending and resume them when loading a save during the AI's turn
- skip redundant start-of-turn setup when resuming and persist pending AI state in save data
- add regression tests covering MCTS resume flows and updated save serialization

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca805798108323971c5c896de90f2d