### PR TITLE
fix: prevent snake trap from triggering on hero attacks

### DIFF
--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -245,7 +245,9 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         await g.playFromHand(g.player, card.id);
         const enemy = new Card({ id: 'enemy-2', name: 'Enemy', type: 'ally', cost: 1, data: { attack: 1, health: 2 }, keywords: [] });
         g.opponent.battlefield.add(enemy);
-        g.combat.declareAttacker(enemy);
+        const friendly = new Card({ id: 'friendly-1', name: 'Friendly', type: 'ally', cost: 1, data: { attack: 1, health: 3 }, keywords: [] });
+        g.player.battlefield.add(friendly);
+        g.combat.declareAttacker(enemy, friendly);
         // Expect 3 snakes summoned for player
         const snakes = g.player.battlefield.cards.filter(c => c.name === 'Snake');
         expect(snakes.length).toBe(3);

--- a/__tests__/effects.snake-trap.test.js
+++ b/__tests__/effects.snake-trap.test.js
@@ -1,0 +1,79 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('Snake Trap does not trigger when the hero is attacked', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.hand.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+  g.resources._pool.set(g.opponent, 10);
+
+  const trapData = g.allCards.find(c => c.id === 'spell-snake-trap');
+  const trap = new Card(trapData);
+  g.player.hand.add(trap);
+  await g.playFromHand(g.player, trap.id);
+
+  const attacker = new Card({
+    name: 'Test Attacker',
+    type: 'ally',
+    cost: 2,
+    data: { attack: 2, health: 2 },
+    keywords: [],
+  });
+  g.opponent.battlefield.add(attacker);
+
+  const initialSecrets = (g.player.hero.data.secrets || []).length;
+  const result = await g.attack(g.opponent, attacker.id);
+
+  expect(result).toBe(true);
+  const snakes = g.player.battlefield.cards.filter(c => c.name === 'Snake');
+  expect(snakes.length).toBe(0);
+  expect((g.player.hero.data.secrets || []).length).toBe(initialSecrets);
+});
+
+test('Snake Trap triggers when a friendly ally is attacked', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.hand.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.resources._pool.set(g.player, 10);
+  g.resources._pool.set(g.opponent, 10);
+
+  const trapData = g.allCards.find(c => c.id === 'spell-snake-trap');
+  const trap = new Card(trapData);
+  g.player.hand.add(trap);
+  await g.playFromHand(g.player, trap.id);
+
+  const defender = new Card({
+    name: 'Friendly Ally',
+    type: 'ally',
+    cost: 2,
+    data: { attack: 1, health: 3 },
+    keywords: [],
+  });
+  g.player.battlefield.add(defender);
+
+  const attacker = new Card({
+    name: 'Enemy Attacker',
+    type: 'ally',
+    cost: 2,
+    data: { attack: 1, health: 2 },
+    keywords: [],
+  });
+  g.opponent.battlefield.add(attacker);
+
+  const result = await g.attack(g.opponent, attacker.id, defender.id);
+
+  expect(result).toBe(true);
+  const snakes = g.player.battlefield.cards.filter(c => c.name === 'Snake');
+  expect(snakes.length).toBe(3);
+  expect(g.player.hero.data.secrets || []).toHaveLength(0);
+});
+

--- a/src/js/systems/ai-mcts.js
+++ b/src/js/systems/ai-mcts.js
@@ -784,18 +784,18 @@ export class MCTS_AI {
           // Prefer RNG from game if available for variety
           block = this.game?.rng?.pick ? this.game.rng.pick(choices) : (choices[0] || null);
         }
+        const target = block || opponent.hero;
         // If Rush and just entered, skip if no non-hero block target
         const enteredTurn = a?.data?.enteredTurn;
         const justEntered = !!(enteredTurn && (enteredTurn === (this.resources?.turns?.turn || 0)));
         if (a?.keywords?.includes?.('Rush') && justEntered && !block) continue;
-        if (!this.combat.declareAttacker(a)) continue;
+        if (!this.combat.declareAttacker(a, target)) continue;
         if (a.data) a.data.attacked = true;
         // Stealth is lost when a unit attacks (AI - MCTS path)
         if (a?.keywords?.includes?.('Stealth')) {
           a.keywords = a.keywords.filter(k => k !== 'Stealth');
         }
         if (block) this.combat.assignBlocker(a.id, block);
-        const target = block || opponent.hero;
         if (player?.log) player.log.push(`Attacked ${target.name} with ${a.name}`);
       }
       this.combat.setDefenderHero(opponent.hero);

--- a/src/js/systems/ai-nn.js
+++ b/src/js/systems/ai-nn.js
@@ -193,9 +193,6 @@ export class NeuralAI {
     const attackers = [player.hero, ...player.battlefield.cards]
       .filter(c => (c.type !== 'equipment') && !c.data?.attacked && ((typeof c.totalAttack === 'function' ? c.totalAttack() : c.data?.attack || 0) > 0));
     for (const a of attackers) {
-      if (!this.combat.declareAttacker(a)) continue;
-      if (a.data) a.data.attacked = true;
-      if (a?.keywords?.includes?.('Stealth')) a.keywords = a.keywords.filter(k => k !== 'Stealth');
       const defenders = [opponent.hero, ...opponent.battlefield.cards.filter(d => d.type !== 'equipment' && d.type !== 'quest')];
       const legal = selectTargets(defenders);
       let block = null;
@@ -208,8 +205,12 @@ export class NeuralAI {
       } else if (legal.length === 1 && legal[0].id !== opponent.hero.id) {
         block = legal[0];
       }
+      const target = block || opponent.hero;
+      if (!this.combat.declareAttacker(a, target)) continue;
+      if (a.data) a.data.attacked = true;
+      if (a?.keywords?.includes?.('Stealth')) a.keywords = a.keywords.filter(k => k !== 'Stealth');
       if (block) this.combat.assignBlocker(a.id, block);
-      player.log.push(`Attacked ${(block||opponent.hero).name} with ${a.name}`);
+      player.log.push(`Attacked ${target.name} with ${a.name}`);
     }
     this.combat.setDefenderHero(opponent.hero);
     const events = this.combat.resolve();

--- a/src/js/systems/combat.js
+++ b/src/js/systems/combat.js
@@ -27,13 +27,13 @@ export class CombatSystem {
     this.bus = bus;
   }
 
-  declareAttacker(attacker) {
+  declareAttacker(attacker, defender = null) {
     // Cannot attack when frozen/stunned
     if (getStat(attacker, 'freezeTurns', 0) > 0) return false;
     // Emit an attack declaration event to allow reactive effects (e.g., secrets)
     if (this.bus) {
       try {
-        this.bus.emit('attackDeclared', { attacker });
+        this.bus.emit('attackDeclared', { attacker, defender });
       } catch (e) {
         // Defensive: do not block combat due to handler errors
         console.error(e);

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -727,11 +727,14 @@ export class EffectSystem {
 
     const opponent = player === game.player ? game.opponent : game.player;
 
-    const handler = async ({ attacker }) => {
-      // Trigger on enemy attack declaration (target-agnostic, similar to Freezing Trap)
+    const handler = async ({ attacker, defender: target }) => {
+      // Trigger only when an enemy attacks one of the player's allies
       if (!attacker) return;
       const isEnemy = opponent.battlefield.cards.includes(attacker) || attacker === opponent.hero;
       if (!isEnemy) return;
+      const isFriendlyAllyTarget =
+        target && target !== player.hero && target.type === 'ally' && player.battlefield.cards.includes(target);
+      if (!isFriendlyAllyTarget) return;
       off();
       logSecretTriggered(game, player, { card, token });
       // Remove the secret indicator when it triggers


### PR DESCRIPTION
## Summary
- provide the attack target when declaring attacks so reactive effects know what was targeted
- ensure Snake Trap only fires for attacks against friendly allies and update game/AI flows accordingly
- add dedicated tests for hero vs ally attacks and update the generic effects test

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca8489f6648323b9966250cecfea83