### PR TITLE
fix: avoid double draw for medium AI turns

### DIFF
--- a/__tests__/game.ai.draw.test.js
+++ b/__tests__/game.ai.draw.test.js
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('easy difficulty still draws at opponent turn start', async () => {
+  const game = new Game();
+  await game.init();
+  game.state.difficulty = 'easy';
+
+  game.opponent.hand.cards = [];
+  game.opponent.library.cards = [
+    new Card({ type: 'ally', name: 'Scout', cost: 1, data: { attack: 1, health: 1 } })
+  ];
+
+  const drawSpy = jest.spyOn(game, 'draw');
+  try {
+    game.turns.setActivePlayer(game.opponent);
+    game.turns.startTurn();
+    expect(drawSpy).toHaveBeenCalledWith(game.opponent, 1);
+    expect(game.opponent.hand.cards).toHaveLength(1);
+  } finally {
+    drawSpy.mockRestore();
+  }
+});
+
+test('medium difficulty MCTS turn draws only once', async () => {
+  const takeTurn = jest.fn(async (player) => {
+    const [card] = player.library.draw(1);
+    if (card) player.hand.add(card);
+  });
+  const game = new Game(null, { createMctsAI: async () => ({ takeTurn }) });
+  await game.init();
+  game.state.difficulty = 'medium';
+
+  game.opponent.hand.cards = [];
+  const first = new Card({ type: 'ally', name: 'Pioneer', cost: 1, data: { attack: 1, health: 1 } });
+  const second = new Card({ type: 'ally', name: 'Adventurer', cost: 1, data: { attack: 1, health: 1 } });
+  game.opponent.library.cards = [first, second];
+
+  const initialLibraryCount = game.opponent.library.cards.length;
+  await game.endTurn();
+
+  expect(takeTurn).toHaveBeenCalledTimes(1);
+  expect(initialLibraryCount - game.opponent.library.cards.length).toBe(1);
+  expect(game.opponent.hand.cards).toHaveLength(1);
+  expect(game.opponent.hand.cards[0].name).toBe('Adventurer');
+});

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -51,26 +51,31 @@ export default class Game {
           player.cardsPlayedThisTurn = 0;
           player.armorGainedThisTurn = 0;
         }
-      const bonus = player?.hero?.data?.nextSpellDamageBonus;
-      if (bonus?.eachTurn) bonus.used = false;
-      if (player?.hero) {
-        player.hero.powerUsed = false;
-        // Reset per-turn attack state
-        player.hero.data.attacked = false;
-        player.hero.data.attacksUsed = 0;
-        player.hero.data.summoningSick = false;
-        for (const c of player.battlefield.cards) {
-          if (c.data) {
-            c.data.attacked = false;
-            c.data.attacksUsed = 0;
-            c.data.summoningSick = false;
+        const bonus = player?.hero?.data?.nextSpellDamageBonus;
+        if (bonus?.eachTurn) bonus.used = false;
+        if (player?.hero) {
+          player.hero.powerUsed = false;
+          // Reset per-turn attack state
+          player.hero.data.attacked = false;
+          player.hero.data.attacksUsed = 0;
+          player.hero.data.summoningSick = false;
+          for (const c of player.battlefield.cards) {
+            if (c.data) {
+              c.data.attacked = false;
+              c.data.attacksUsed = 0;
+              c.data.summoningSick = false;
+            }
+          }
+          if (player.hero.passive?.length) {
+            this.effects.execute(player.hero.passive, { game: this, player, card: player.hero });
           }
         }
-        if (player.hero.passive?.length) {
-          this.effects.execute(player.hero.passive, { game: this, player, card: player.hero });
-        }
-      }
-        if (player) this.draw(player, 1);
+        const difficulty = this.state?.difficulty || 'easy';
+        const opponentIsAI = typeof this.aiPlayers?.has === 'function' && this.aiPlayers.has('opponent');
+        const aiHandlesDraw = opponentIsAI
+          && player === this.opponent
+          && (difficulty === 'medium' || difficulty === 'hard' || difficulty === 'nightmare');
+        if (player && !aiHandlesDraw) this.draw(player, 1);
       });
 
       this.turns.bus.on('phase:end', ({ phase }) => {


### PR DESCRIPTION
## Summary
- prevent the turn start handler from drawing for MCTS/NN difficulties so the AI only draws once
- add regression coverage to confirm easy difficulty still draws automatically and medium draws once when ending the player's turn

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cab6f15de08323813d4dc552bbc891