### PR TITLE
fix: use deterministic seeds for training eval

### DIFF
--- a/tools/train.mjs
+++ b/tools/train.mjs
@@ -75,8 +75,8 @@ async function evalCandidate(model, { games = 5, maxRounds = 20, opponentMode = 
   let total = 0;
   for (let g = 0; g < games; g++) {
     const game = new Game(null, { aiPlayers: ['player', 'opponent'] });
-    // Randomize RNG seed per evaluation to diversify decks/hands
-    const seed = (Math.floor(Math.random() * 0xFFFFFFFF)) >>> 0;
+    // Use deterministic RNG seeds per evaluation so every candidate sees identical matchups
+    const seed = g >>> 0;
     game.rng = new RNG(seed);
     await game.setupMatch();
     setActiveModel(model); // ensure endTurn or direct AI uses this model

--- a/tools/train.worker.mjs
+++ b/tools/train.worker.mjs
@@ -18,8 +18,8 @@ async function evalCandidate(model, { games = 5, maxRounds = 20, opponentMode = 
   let total = 0;
   for (let g = 0; g < games; g++) {
     const game = new Game(null, { aiPlayers: ['player', 'opponent'] });
-    // Randomize RNG seed per evaluation to diversify matchups
-    const seed = (Math.floor(Math.random() * 0xFFFFFFFF)) >>> 0;
+    // Deterministic RNG seeds ensure all candidates face identical matchups
+    const seed = g >>> 0;
     game.rng = new RNG(seed);
     await game.setupMatch();
     setActiveModel(model);


### PR DESCRIPTION
## Summary
- use fixed RNG seeds for each game when evaluating candidates in the CLI trainer
- mirror the deterministic seeds in the worker evaluator so every candidate faces identical matchups

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cac4a38cac83238a7d579e0106edd4