### PR TITLE
fix: skip targeting prompt for frozen attackers

### DIFF
--- a/__tests__/freeze.targeting-prompt.test.js
+++ b/__tests__/freeze.targeting-prompt.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('frozen attackers do not trigger the target selection prompt', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  const attacker = new Card({
+    id: 'test-attacker',
+    type: 'ally',
+    name: 'Test Attacker',
+    data: { attack: 3, health: 3, summoningSick: false, enteredTurn: (g.turns.turn || 0) - 1 }
+  });
+  attacker.owner = g.player;
+  g.player.battlefield.add(attacker);
+
+  const enemy = new Card({
+    id: 'enemy-blocker',
+    type: 'ally',
+    name: 'Enemy Blocker',
+    data: { attack: 1, health: 2 }
+  });
+  enemy.owner = g.opponent;
+  g.opponent.battlefield.add(enemy);
+
+  const promptSpy = jest.fn(async () => enemy);
+  g.promptTarget = promptSpy;
+
+  attacker.data.freezeTurns = 1;
+  const blocked = await g.attack(g.player, attacker.id);
+  expect(blocked).toBe(false);
+  expect(promptSpy).not.toHaveBeenCalled();
+
+  attacker.data.freezeTurns = 0;
+  attacker.data.attacksUsed = 0;
+  promptSpy.mockClear();
+
+  const resolved = await g.attack(g.player, attacker.id);
+  expect(resolved).toBe(true);
+  expect(promptSpy).toHaveBeenCalled();
+});

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -596,6 +596,7 @@ export default class Game {
     const defender = player === this.player ? this.opponent : this.player;
     const card = [player.hero, ...player.battlefield.cards].find(c => c.id === cardId);
     if (!card) return false;
+    if ((card?.data?.freezeTurns || 0) > 0) return false;
     const atk = typeof card.totalAttack === 'function' ? card.totalAttack() : (card.data?.attack ?? 0);
     if (atk < 1) return false;
     // Block if summoning sick (no Rush)


### PR DESCRIPTION
## Summary
- prevent `Game.attack` from opening the targeting prompt when the attacker is frozen
- add a regression test ensuring frozen attackers skip the prompt and resume normally once unfrozen

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb286b0e988323911e8465c855bc98