### PR TITLE
Add hybrid difficulty policy integration and tests

### DIFF
--- a/__tests__/ai.nn.policy-value.test.js
+++ b/__tests__/ai.nn.policy-value.test.js
@@ -1,0 +1,73 @@
+import { jest } from '@jest/globals';
+import { NeuralPolicyValueModel } from '../src/js/systems/ai-nn.js';
+import { actionSignature } from '../src/js/systems/ai-signatures.js';
+
+test('NeuralPolicyValueModel.evaluate scores snapshot states from MCTS clones', () => {
+  const outputs = [0.2, 0.4, 0.1];
+  const fakeModel = {
+    forward: jest.fn(() => [outputs.shift() ?? 0]),
+  };
+  const model = new NeuralPolicyValueModel({ model: fakeModel, temperature: 0.5 });
+
+  const ally = {
+    id: 'ally-1',
+    name: 'Shieldbearer',
+    type: 'ally',
+    cost: 2,
+    keywords: ['Taunt'],
+    data: { attack: 1, health: 4 }
+  };
+  const spell = {
+    id: 'spell-1',
+    name: 'Arcane Shot',
+    type: 'spell',
+    cost: 1,
+    data: {},
+    keywords: []
+  };
+  const state = {
+    turn: 4,
+    pool: 5,
+    powerAvailable: true,
+    player: {
+      hero: { id: 'hero-1', name: 'Rexxar', type: 'hero', data: { health: 25, armor: 2 }, keywords: [] },
+      hand: { cards: [ally, spell] },
+      battlefield: { cards: [{ id: 'token-1', name: 'Wolf', type: 'ally', keywords: [], data: { attack: 2, health: 2 } }] },
+      graveyard: { cards: [] },
+      cardsPlayedThisTurn: 0,
+      armorGainedThisTurn: 0,
+    },
+    opponent: {
+      hero: { id: 'hero-2', name: 'Guldan', type: 'hero', data: { health: 22, armor: 0 }, keywords: [] },
+      battlefield: { cards: [{ id: 'opp-ally', name: 'Imp', type: 'ally', keywords: ['Taunt'], data: { attack: 1, health: 3 } }] },
+      hand: { cards: [] },
+      __mctsPool: 4,
+    },
+  };
+
+  const actions = [
+    { card: ally, usePower: false, end: false },
+    { card: null, usePower: true, end: false },
+    { card: null, usePower: false, end: true },
+  ];
+
+  const result = model.evaluate(state, actions);
+
+  expect(fakeModel.forward).toHaveBeenCalledTimes(actions.length);
+  const featureLength = fakeModel.forward.mock.calls[0][0].length;
+  expect(featureLength).toBeGreaterThan(30);
+
+  const sigPlay = actionSignature(actions[0]);
+  const sigPower = actionSignature(actions[1]);
+  const sigEnd = actionSignature(actions[2]);
+
+  expect(result.stateValue).toBeCloseTo(0.4, 5);
+  expect(result.actionValues.get(sigPlay)).toBeCloseTo(0.2, 5);
+  expect(result.actionValues.get(sigPower)).toBeCloseTo(0.4, 5);
+  expect(result.actionValues.get(sigEnd)).toBeCloseTo(0.1, 5);
+
+  const policySum = Array.from(result.policy.values()).reduce((sum, val) => sum + val, 0);
+  expect(policySum).toBeCloseTo(1, 5);
+  expect(result.policy.get(sigPower)).toBeGreaterThan(result.policy.get(sigPlay));
+});
+

--- a/__tests__/game.hybrid.test.js
+++ b/__tests__/game.hybrid.test.js
@@ -1,0 +1,25 @@
+import Game from '../src/js/game.js';
+import MCTS_AI from '../src/js/systems/ai-mcts.js';
+import { NeuralPolicyValueModel, getActiveModel, setActiveModel } from '../src/js/systems/ai-nn.js';
+
+beforeEach(() => {
+  setActiveModel(null);
+});
+
+afterEach(() => {
+  setActiveModel(null);
+});
+
+test('creating MCTS for hybrid difficulty injects neural policy model', async () => {
+  const game = new Game(null);
+  const ai = await game._createMctsAI('hybrid');
+
+  expect(ai).toBeInstanceOf(MCTS_AI);
+  expect(ai.iterations).toBe(6500);
+  expect(ai.rolloutDepth).toBe(18);
+  expect(ai.policyValueModel).toBeInstanceOf(NeuralPolicyValueModel);
+
+  const activeModel = getActiveModel();
+  expect(activeModel).toBe(ai.policyValueModel.model);
+});
+

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -22,6 +22,9 @@ try {
   const settings = loadSettings();
   if (settings?.difficulty) {
     game.state.difficulty = settings.difficulty;
+    if (settings.difficulty === 'nightmare' || settings.difficulty === 'hybrid') {
+      game.preloadNeuralModel?.();
+    }
   }
   if (settings?.lastDeck) {
     const deck = rehydrateDeck(settings.lastDeck, game.allCards);

--- a/src/js/systems/ai-nn.js
+++ b/src/js/systems/ai-nn.js
@@ -1,10 +1,11 @@
-// Neural network driven AI for "nightmare" difficulty.
+// Neural network driven AI for "nightmare" difficulty and hybrid policy guidance.
 // Uses a small MLP to score Q(s,a) and pick the best action.
 // Training uses population-based mutation in tools/train.mjs and stores model at data/models/best.json
 
 import CombatSystem from './combat.js';
 import { selectTargets } from './targeting.js';
 import MLP from './nn.js';
+import { actionSignature } from './ai-signatures.js';
 
 let ActiveModel = null; // module-level active model
 
@@ -33,50 +34,183 @@ export async function loadModelFromDiskOrFetch() {
   }
 }
 
-// Feature engineering
-// State features (player-centric, 20 dims approx):
-// [ turn/20, pHP/40, pArmor/20, pPool/10, pAvail/10, pHand/10, pAllies, pAtkSum/50, pHpSum/100, pMaxAtk/20,
-//   oHP/40, oArmor/20, oPool/10, oAvail/10, oHand/10, oAllies, oAtkSum/50, oHpSum/100, oTaunts, powerAvail ]
-// Action features (15 dims currently): one-hot type (3), cost/10, cardAtk/20, cardHp/20, type enum (ally=1,spell=2,equip=3,
-// quest=4)/4, plus flags: rush, taunt, stealth, divineShield, windfury, battlecry, reflect, lifesteal (8).
-// Combined with state features we feed 35 inputs, leaving extra padding in the MLP's 38-wide input layer for future tweaks.
-
 function clamp01(x) { return x < 0 ? 0 : x > 1 ? 1 : x; }
 
-function stateFeatures({ game, player, opponent, powerAvailable }) {
-  const res = game.resources;
-  const turn = game?.turns?.turn || 1;
-  const pHP = (player.hero?.data?.health ?? 0);
-  const pArmor = (player.hero?.data?.armor ?? 0);
-  const pPool = res.pool(player);
-  const pAvail = res.available(player);
-  const pHand = player.hand.size();
-  const pAllies = player.battlefield.cards.filter(c => c.type !== 'quest' && c.type !== 'equipment').length;
-  const pAtkSum = sum(player.battlefield.cards.map(c => (c.data?.attack || 0)));
-  const pHpSum = sum(player.battlefield.cards.map(c => (c.data?.health || 0)));
-  const pMaxAtk = max(0, player.battlefield.cards.map(c => (c.data?.attack || 0)));
+function listCards(zone) {
+  if (!zone) return [];
+  if (Array.isArray(zone)) return zone.filter(Boolean);
+  if (Array.isArray(zone.cards)) return zone.cards.filter(Boolean);
+  if (typeof zone.size === 'function' && Array.isArray(zone.cards)) return zone.cards.filter(Boolean);
+  return [];
+}
 
-  const oHP = (opponent.hero?.data?.health ?? 0);
-  const oArmor = (opponent.hero?.data?.armor ?? 0);
-  const oPool = res.pool(opponent);
-  const oAvail = res.available(opponent);
-  const oHand = opponent.hand.size();
-  const oAllies = opponent.battlefield.cards.filter(c => c.type !== 'quest' && c.type !== 'equipment').length;
-  const oAtkSum = sum(opponent.battlefield.cards.map(c => (c.data?.attack || 0)));
-  const oHpSum = sum(opponent.battlefield.cards.map(c => (c.data?.health || 0)));
-  const oTaunts = opponent.battlefield.cards.filter(c => c.keywords?.includes('Taunt')).length;
+function getCardStat(card, key) {
+  if (!card) return 0;
+  const data = card.data || {};
+  const direct = data[key];
+  if (typeof direct === 'number') return direct;
+  const fallback = card[key];
+  return typeof fallback === 'number' ? fallback : 0;
+}
 
+function hasKeyword(card, keyword) {
+  if (!card) return false;
+  const kw = card.keywords;
+  if (!kw) return false;
+  if (Array.isArray(kw)) return kw.includes(keyword);
+  if (typeof kw.has === 'function') return kw.has(keyword);
+  return false;
+}
+
+function summarizeSide(side) {
+  const hero = side?.hero || {};
+  const heroData = hero.data || {};
+  const battlefield = listCards(side?.battlefield);
+  const allies = battlefield.filter(c => c && c.type !== 'equipment' && c.type !== 'quest');
+  let attackSum = 0;
+  let hpSum = 0;
+  let maxAttack = 0;
+  let tauntCount = 0;
+  for (const card of allies) {
+    const atk = getCardStat(card, 'attack');
+    const hp = getCardStat(card, 'health');
+    attackSum += atk;
+    hpSum += hp;
+    if (atk > maxAttack) maxAttack = atk;
+    if (hasKeyword(card, 'Taunt')) tauntCount += 1;
+  }
+  return {
+    heroHealth: heroData.health ?? hero.health ?? 0,
+    heroArmor: heroData.armor ?? hero.armor ?? 0,
+    handCount: listCards(side?.hand).length,
+    alliesCount: allies.length,
+    attackSum,
+    hpSum,
+    maxAttack,
+    tauntCount,
+  };
+}
+
+function stateDescriptorFromLive({
+  game = null,
+  resources = null,
+  player = null,
+  opponent = null,
+  powerAvailable = false,
+  turnOverride = null,
+  poolOverride = null,
+  opponentPoolOverride = null,
+  opponentAvailableOverride = null,
+} = {}) {
+  const res = resources || game?.resources || null;
+  const turn = typeof turnOverride === 'number'
+    ? turnOverride
+    : (typeof game?.turns?.turn === 'number'
+      ? game.turns.turn
+      : (typeof res?.turns?.turn === 'number' ? res.turns.turn : 1));
+  const fallbackPool = Math.min(10, Math.max(0, turn));
+  const pool = typeof poolOverride === 'number'
+    ? poolOverride
+    : (typeof res?.pool === 'function' ? res.pool(player) : fallbackPool);
+  const availRaw = typeof res?.available === 'function' ? res.available(player) : null;
+  const playerAvailable = typeof availRaw === 'number' ? availRaw : pool;
+  const oppPool = typeof opponentPoolOverride === 'number'
+    ? opponentPoolOverride
+    : (typeof res?.pool === 'function' ? res.pool(opponent) : fallbackPool);
+  const oppAvailRaw = typeof opponentAvailableOverride === 'number'
+    ? opponentAvailableOverride
+    : (typeof res?.available === 'function' ? res.available(opponent) : null);
+  const oppAvailable = typeof oppAvailRaw === 'number' ? oppAvailRaw : oppPool;
+  const playerSummary = summarizeSide(player);
+  const opponentSummary = summarizeSide(opponent);
+  return {
+    turn,
+    powerAvailable: !!powerAvailable,
+    player: {
+      ...playerSummary,
+      pool: Math.max(0, pool || 0),
+      available: Math.max(0, playerAvailable || 0),
+    },
+    opponent: {
+      ...opponentSummary,
+      pool: Math.max(0, oppPool || 0),
+      available: Math.max(0, oppAvailable || 0),
+    },
+  };
+}
+
+function stateDescriptorFromSnapshot(state = {}) {
+  const turn = typeof state.turn === 'number' ? state.turn : 1;
+  const fallbackPool = Math.min(10, Math.max(0, turn));
+  const playerPool = typeof state.pool === 'number' ? state.pool : fallbackPool;
+  const playerAvailable = typeof state.available === 'number' ? state.available : playerPool;
+  const opponentPool = typeof state.opponentPool === 'number'
+    ? state.opponentPool
+    : (typeof state.opponent?.__mctsPool === 'number' ? state.opponent.__mctsPool : fallbackPool);
+  const opponentAvailable = typeof state.opponentAvailable === 'number' ? state.opponentAvailable : opponentPool;
+  const playerSummary = summarizeSide(state.player || {});
+  const opponentSummary = summarizeSide(state.opponent || {});
+  return {
+    turn,
+    powerAvailable: !!state.powerAvailable,
+    player: {
+      ...playerSummary,
+      pool: Math.max(0, playerPool || 0),
+      available: Math.max(0, playerAvailable || 0),
+    },
+    opponent: {
+      ...opponentSummary,
+      pool: Math.max(0, opponentPool || 0),
+      available: Math.max(0, opponentAvailable || 0),
+    },
+  };
+}
+
+function stateFeaturesFromDescriptor(desc = {}) {
+  const { player = {}, opponent = {} } = desc;
   return [
-    clamp01(turn / 20),
-    clamp01(pHP / 40), clamp01(pArmor / 20), clamp01(pPool / 10), clamp01(pAvail / 10), clamp01(pHand / 10), clamp01(pAllies / 7),
-    clamp01(pAtkSum / 50), clamp01(pHpSum / 100), clamp01(pMaxAtk / 20),
-    clamp01(oHP / 40), clamp01(oArmor / 20), clamp01(oPool / 10), clamp01(oAvail / 10), clamp01(oHand / 10), clamp01(oAllies / 7),
-    clamp01(oAtkSum / 50), clamp01(oHpSum / 100), clamp01(oTaunts / 5), powerAvailable ? 1 : 0,
+    clamp01((desc.turn || 0) / 20),
+    clamp01((player.heroHealth || 0) / 40),
+    clamp01((player.heroArmor || 0) / 20),
+    clamp01((player.pool || 0) / 10),
+    clamp01((player.available || 0) / 10),
+    clamp01((player.handCount || 0) / 10),
+    clamp01((player.alliesCount || 0) / 7),
+    clamp01((player.attackSum || 0) / 50),
+    clamp01((player.hpSum || 0) / 100),
+    clamp01((player.maxAttack || 0) / 20),
+    clamp01((opponent.heroHealth || 0) / 40),
+    clamp01((opponent.heroArmor || 0) / 20),
+    clamp01((opponent.pool || 0) / 10),
+    clamp01((opponent.available || 0) / 10),
+    clamp01((opponent.handCount || 0) / 10),
+    clamp01((opponent.alliesCount || 0) / 7),
+    clamp01((opponent.attackSum || 0) / 50),
+    clamp01((opponent.hpSum || 0) / 100),
+    clamp01((opponent.tauntCount || 0) / 5),
+    desc.powerAvailable ? 1 : 0,
   ];
 }
 
+function stateFeatures(state) {
+  if (!state) return stateFeaturesFromDescriptor();
+  if (state.kind === 'live' || state.type === 'live' || state.game || state.resources || state.resourceSystem) {
+    return stateFeaturesFromDescriptor(stateDescriptorFromLive({
+      game: state.game || null,
+      resources: state.resources || state.resourceSystem || null,
+      player: state.player || null,
+      opponent: state.opponent || null,
+      powerAvailable: state.powerAvailable || false,
+      turnOverride: typeof state.turn === 'number' ? state.turn : null,
+      poolOverride: typeof state.pool === 'number' ? state.pool : null,
+      opponentPoolOverride: typeof state.opponentPool === 'number' ? state.opponentPool : null,
+      opponentAvailableOverride: typeof state.opponentAvailable === 'number' ? state.opponentAvailable : null,
+    }));
+  }
+  return stateFeaturesFromDescriptor(stateDescriptorFromSnapshot(state));
+}
+
 function actionFeatures(action) {
-  // type one-hot
   const isPlay = action?.card ? 1 : 0;
   const isPower = action?.usePower ? 1 : 0;
   const isEnd = action?.end ? 1 : 0;
@@ -86,36 +220,79 @@ function actionFeatures(action) {
   if (action?.card) {
     const c = action.card;
     cost = c.cost || 0;
-    atk = c.data?.attack || 0;
-    hp = c.data?.health || 0;
+    atk = getCardStat(c, 'attack');
+    hp = getCardStat(c, 'health');
     typeEnc = (c.type === 'ally' ? 1 : c.type === 'spell' ? 2 : c.type === 'equipment' ? 3 : c.type === 'quest' ? 4 : 0);
-    const kw = c.keywords || [];
-    rush = kw.includes('Rush') ? 1 : 0;
-    taunt = kw.includes('Taunt') ? 1 : 0;
-    stealth = kw.includes('Stealth') ? 1 : 0;
-    divineShield = kw.includes('Divine Shield') ? 1 : 0;
-    windfury = kw.includes('Windfury') ? 1 : 0;
-    battlecry = kw.includes('Battlecry') ? 1 : 0;
-    reflect = kw.includes('Reflect') ? 1 : 0;
-    lifesteal = kw.includes('Lifesteal') ? 1 : 0;
+    rush = hasKeyword(c, 'Rush') ? 1 : 0;
+    taunt = hasKeyword(c, 'Taunt') ? 1 : 0;
+    stealth = hasKeyword(c, 'Stealth') ? 1 : 0;
+    divineShield = hasKeyword(c, 'Divine Shield') ? 1 : 0;
+    windfury = hasKeyword(c, 'Windfury') ? 1 : 0;
+    battlecry = hasKeyword(c, 'Battlecry') ? 1 : 0;
+    reflect = hasKeyword(c, 'Reflect') ? 1 : 0;
+    lifesteal = hasKeyword(c, 'Lifesteal') ? 1 : 0;
   }
   return [
     isPlay, isPower, isEnd,
     clamp01(cost / 10), clamp01(atk / 20), clamp01(hp / 20), clamp01(typeEnc / 4),
     rush, taunt, stealth, divineShield, windfury, battlecry, reflect, lifesteal,
-    // pad to fixed length if needed later
   ];
 }
 
-function sum(arr) { return arr.reduce((a,b)=>a+(b||0),0); }
-function max(init, arr) { return arr.reduce((a,b)=>Math.max(a,(b||0)), init); }
+export class NeuralPolicyValueModel {
+  constructor({ model = null, temperature = 1 } = {}) {
+    this.model = model || ActiveModel || new MLP([38, 64, 64, 1]);
+    this.temperature = (typeof temperature === 'number' && temperature > 0) ? temperature : 1;
+  }
+
+  evaluate(state, actions = []) {
+    const stateVec = stateFeatures(state);
+    const actionValues = new Map();
+    const policy = new Map();
+    const scores = [];
+    const keys = [];
+    if (Array.isArray(actions)) {
+      for (const action of actions) {
+        const key = actionSignature(action);
+        const vec = stateVec.concat(actionFeatures(action));
+        const out = this.model.forward(vec);
+        const value = Array.isArray(out) && out.length ? (out[0] || 0) : 0;
+        actionValues.set(key, value);
+        scores.push(value);
+        keys.push(key);
+      }
+    }
+    let stateValue = 0;
+    if (scores.length) {
+      stateValue = Math.max(...scores);
+      const temp = this.temperature || 1;
+      const logits = scores.map((v) => v / temp);
+      const maxLogit = Math.max(...logits);
+      let sumExp = 0;
+      const exps = logits.map((v) => {
+        const val = Math.exp(v - maxLogit);
+        sumExp += val;
+        return val;
+      });
+      if (sumExp > 0) {
+        exps.forEach((val, idx) => {
+          policy.set(keys[idx], val / sumExp);
+        });
+      } else {
+        const uniform = 1 / keys.length;
+        keys.forEach((key) => policy.set(key, uniform));
+      }
+    }
+    return { stateValue, actionValues, policy };
+  }
+}
 
 export class NeuralAI {
   constructor({ game, resourceSystem, combatSystem, model = null } = {}) {
     this.game = game || null;
     this.resources = resourceSystem;
     this.combat = combatSystem || new CombatSystem();
-    this.model = model || ActiveModel || new MLP([38,64,64,1]);
+    this.model = model || ActiveModel || new MLP([38, 64, 64, 1]);
   }
 
   _legalActions(state) {
@@ -131,14 +308,21 @@ export class NeuralAI {
   }
 
   _score(state, action) {
-    const s = stateFeatures(state);
+    const s = stateFeatures({
+      kind: 'live',
+      game: this.game,
+      resources: this.resources,
+      player: state.player,
+      opponent: state.opponent,
+      powerAvailable: state.powerAvailable,
+    });
     const a = actionFeatures(action);
     const x = s.concat(a);
     let y = this.model.forward(x)[0] || 0;
-    // Light heuristic to avoid ending early when actions exist
     if (action?.end) {
-      const hasPlayable = state.player.hand.cards.some(c => (c.cost || 0) <= state.pool) || (state.powerAvailable && state.pool >= 2);
-      if (hasPlayable) y -= 0.1; // small penalty nudging away from premature end
+      const hasPlayable = state.player.hand.cards.some(c => (c.cost || 0) <= state.pool)
+        || (state.powerAvailable && state.pool >= 2);
+      if (hasPlayable) y -= 0.1;
     }
     return y;
   }
@@ -154,25 +338,30 @@ export class NeuralAI {
       if (v > bestV) { bestV = v; best = a; }
       if (!a.end && v > bestNonEndV) { bestNonEndV = v; bestNonEnd = a; }
     }
-    // If best is end while we have any non-end actions, prefer non-end unless it's dramatically worse
     if (best?.end && bestNonEnd) {
-      const margin = 0.05; // allow end only if clearly better
+      const margin = 0.05;
       if (bestV <= bestNonEndV + margin) return bestNonEnd;
     }
     return best;
   }
 
   async takeTurn(player, opponent = null) {
-    // Start of turn sequence
     this.resources.startTurn(player);
     const drawn = player.library.draw(1);
     if (drawn[0]) player.hand.add(drawn[0]);
 
-    // Action phase: pick greedily until choose to end
     let powerAvailable = !!(player.hero?.active?.length) && !player.hero.powerUsed;
     while (true) {
       const pool = this.resources.pool(player);
-      const state = { game: this.game, player, opponent, powerAvailable, pool };
+      const state = {
+        kind: 'live',
+        game: this.game,
+        resources: this.resources,
+        player,
+        opponent,
+        powerAvailable,
+        pool,
+      };
       const action = this._chooseAction(state);
       if (!action || action.end) break;
       if (action.card) {
@@ -184,11 +373,9 @@ export class NeuralAI {
         if (!ok) break;
         powerAvailable = false;
       }
-      // Update power availability
       powerAvailable = !!(player.hero?.active?.length) && !player.hero.powerUsed;
     }
 
-    // Combat: simple heuristic similar to easy/MCTS hybrid
     this.combat.clear();
     const attackers = [player.hero, ...player.battlefield.cards]
       .filter(c => (c.type !== 'equipment') && !c.data?.attacked && ((typeof c.totalAttack === 'function' ? c.totalAttack() : c.data?.attack || 0) > 0));
@@ -197,11 +384,10 @@ export class NeuralAI {
       const legal = selectTargets(defenders);
       let block = null;
       if (legal.length > 1) {
-        // Prefer lowest health taunt, else lowest health unit
         const nonHero = legal.filter(t => t.id !== opponent.hero.id);
         const taunts = nonHero.filter(t => t.keywords?.includes('Taunt'));
-        const pool = (taunts.length ? taunts : nonHero);
-        block = pool.sort((x,y)=> (x.data?.health||0)-(y.data?.health||0))[0] || null;
+        const poolChoices = (taunts.length ? taunts : nonHero);
+        block = poolChoices.sort((x, y) => (x.data?.health || 0) - (y.data?.health || 0))[0] || null;
       } else if (legal.length === 1 && legal[0].id !== opponent.hero.id) {
         block = legal[0];
       }

--- a/src/js/systems/ai-signatures.js
+++ b/src/js/systems/ai-signatures.js
@@ -1,0 +1,31 @@
+export function cardSignature(card) {
+  if (!card) return 'no-card';
+  if (card.id) return `id:${card.id}`;
+  const data = card.data || {};
+  const attack = data.attack ?? card.attack ?? '';
+  const health = data.health ?? card.health ?? '';
+  const armor = data.armor ?? card.armor ?? '';
+  const durability = data.durability ?? card.durability ?? '';
+  const keywords = Array.isArray(card.keywords) ? [...card.keywords].sort().join('.') : '';
+  const parts = [
+    `name:${card.name || ''}`,
+    `type:${card.type || ''}`,
+    `cost:${card.cost ?? ''}`,
+    `atk:${attack}`,
+    `hp:${health}`,
+  ];
+  if (armor !== '') parts.push(`armor:${armor}`);
+  if (durability !== '') parts.push(`dur:${durability}`);
+  if (keywords) parts.push(`kw:${keywords}`);
+  return parts.join('|');
+}
+
+export function actionSignature(action) {
+  if (!action) return 'noop';
+  const cardPart = action.card ? cardSignature(action.card) : 'no-card';
+  const usePower = action.usePower ? 'power:1' : 'power:0';
+  const end = action.end ? 'end:1' : 'end:0';
+  return `${cardPart}|${usePower}|${end}`;
+}
+
+export default actionSignature;

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -361,12 +361,15 @@ export function renderPlay(container, game, { onUpdate, onOpenDeckBuilder, onNew
   const initialMount = !controls || !board;
   if (initialMount) {
     container.innerHTML = '';
-    const diffOptions = ['easy', 'medium', 'hard', 'nightmare'];
+    const diffOptions = ['easy', 'medium', 'hard', 'hybrid', 'nightmare'];
     const diffSelect = el('select', {
       class: 'select-difficulty',
       onchange: (e) => {
         const v = e.target.value;
         if (game.state) game.state.difficulty = v;
+        if (v === 'nightmare' || v === 'hybrid') {
+          game.preloadNeuralModel?.();
+        }
         try { saveDifficulty(v); } catch {}
         onUpdate?.();
       }


### PR DESCRIPTION
## Summary
- add shared action and card signature helpers consumed by the neural and MCTS AIs
- expose a NeuralPolicyValueModel with snapshot-safe feature extraction and let the hybrid MCTS inject it
- preload the neural model for hybrid/nightmare difficulty in the game flow and surface the new difficulty in the UI
- add tests covering hybrid difficulty persistence, MCTS construction, and neural policy evaluation

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb841956e88323baf342a240456776