### PR TITLE
Fix Spirit Wolves from Feral Spirit lacking Taunt

### DIFF
--- a/__tests__/feral-spirit.taunt.test.js
+++ b/__tests__/feral-spirit.taunt.test.js
@@ -1,0 +1,25 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+test('Feral Spirit summons taunt wolves for the opponent', async () => {
+  const g = new Game();
+  await g.setupMatch();
+
+  g.player.battlefield.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.opponent.hand.cards = [];
+  g.resources._pool.set(g.opponent, 10);
+  g.turns.turn = 10;
+  g.turns.setActivePlayer(g.opponent);
+
+  const feralSpiritData = g.allCards.find(c => c.id === 'spell-feral-spirit');
+  const feralSpirit = new Card(feralSpiritData);
+  g.opponent.hand.add(feralSpirit);
+
+  await g.playFromHand(g.opponent, feralSpirit.id);
+
+  const wolves = g.opponent.battlefield.cards.filter(c => c.name === 'Spirit Wolf');
+  expect(wolves).toHaveLength(2);
+  expect(wolves.every(w => w.keywords?.includes('Taunt'))).toBe(true);
+});
+

--- a/data/cards/spell.json
+++ b/data/cards/spell.json
@@ -255,7 +255,9 @@
           "name": "Spirit Wolf",
           "attack": 2,
           "health": 3,
-          "keywords": []
+          "keywords": [
+            "Taunt"
+          ]
         },
         "count": 2
       },


### PR DESCRIPTION
## Summary
- ensure Feral Spirit summons Spirit Wolves with Taunt so they protect the hero
- add a regression test covering the opponent casting Feral Spirit

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb9efca2488323bc3d9ab5b3a7d156