### PR TITLE
feat: enforce random deck builder limits

### DIFF
--- a/__tests__/ui.clear-deck-button.test.js
+++ b/__tests__/ui.clear-deck-button.test.js
@@ -3,10 +3,27 @@ import { jest } from '@jest/globals';
 import { renderDeckBuilder } from '../src/js/ui/deckbuilder.js';
 import { fillDeckRandomly } from '../src/js/utils/deckbuilder.js';
 
-test('clear deck button empties deck and disables use', async () => {
+const createCardPool = () => {
   const hero = { id: 'h1', name: 'Hero', type: 'hero', text: '', data: { armor: 0 } };
-  const ally = { id: 'a1', name: 'Ally', type: 'ally', text: '', cost: 1, data: { attack: 1, health: 1 } };
-  const allCards = [hero, ally];
+  const allies = Array.from({ length: 20 }, (_, i) => ({
+    id: `ally-${i + 1}`,
+    name: `Ally ${i + 1}`,
+    type: 'ally',
+    text: '',
+    cost: 1,
+    data: { attack: 1, health: 1 },
+  }));
+  const spells = Array.from({ length: 10 }, (_, i) => ({
+    id: `spell-${i + 1}`,
+    name: `Spell ${i + 1}`,
+    type: 'spell',
+    text: '',
+  }));
+  return { hero, allCards: [hero, ...allies, ...spells] };
+};
+
+test('clear deck button empties deck and disables use', async () => {
+  const { hero, allCards } = createCardPool();
   const game = { reset: jest.fn().mockResolvedValue(), allCards };
 
   const main = document.createElement('main');

--- a/__tests__/ui.fill-random-button.test.js
+++ b/__tests__/ui.fill-random-button.test.js
@@ -3,10 +3,27 @@ import { jest } from '@jest/globals';
 import { renderDeckBuilder } from '../src/js/ui/deckbuilder.js';
 import { fillDeckRandomly } from '../src/js/utils/deckbuilder.js';
 
-test('fill random button fills hero and 60 cards and enables use', async () => {
+const createCardPool = () => {
   const hero = { id: 'h1', name: 'Hero', type: 'hero', text: '', data: { armor: 0 } };
-  const ally = { id: 'a1', name: 'Ally', type: 'ally', text: '', cost: 1, data: { attack: 1, health: 1 } };
-  const allCards = [hero, ally];
+  const allies = Array.from({ length: 20 }, (_, i) => ({
+    id: `ally-${i + 1}`,
+    name: `Ally ${i + 1}`,
+    type: 'ally',
+    text: '',
+    cost: 1,
+    data: { attack: 1, health: 1 },
+  }));
+  const spells = Array.from({ length: 10 }, (_, i) => ({
+    id: `spell-${i + 1}`,
+    name: `Spell ${i + 1}`,
+    type: 'spell',
+    text: '',
+  }));
+  return { hero, allCards: [hero, ...allies, ...spells] };
+};
+
+test('fill random button fills hero and 60 cards and enables use', async () => {
+  const { hero, allCards } = createCardPool();
   const game = { reset: jest.fn().mockResolvedValue(), allCards };
 
   // Build minimal DOM similar to app layout

--- a/__tests__/utils.deckbuilder.test.js
+++ b/__tests__/utils.deckbuilder.test.js
@@ -1,18 +1,97 @@
 import { fillDeckRandomly } from '../src/js/utils/deckbuilder.js';
 import { RNG } from '../src/js/utils/rng.js';
 
+const buildAllCards = () => {
+  const hero = { id: 'hero-1', name: 'Hero', type: 'hero', text: '', data: { armor: 0 } };
+  const quests = Array.from({ length: 2 }, (_, i) => ({
+    id: `quest-${i + 1}`,
+    name: `Quest ${i + 1}`,
+    type: 'quest',
+    text: '',
+  }));
+  const allies = Array.from({ length: 20 }, (_, i) => ({
+    id: `ally-${i + 1}`,
+    name: `Ally ${i + 1}`,
+    type: 'ally',
+    text: '',
+    cost: 1,
+    data: { attack: 1, health: 1 },
+  }));
+  const equipments = Array.from({ length: 2 }, (_, i) => ({
+    id: `equipment-${i + 1}`,
+    name: `Equipment ${i + 1}`,
+    type: 'equipment',
+    text: '',
+  }));
+  const spells = Array.from({ length: 10 }, (_, i) => ({
+    id: `spell-${i + 1}`,
+    name: `Spell ${i + 1}`,
+    type: 'spell',
+    text: '',
+  }));
+
+  return {
+    hero,
+    quests,
+    allies,
+    equipments,
+    spells,
+    allCards: [hero, ...quests, ...allies, ...equipments, ...spells],
+  };
+};
+
 describe('fillDeckRandomly', () => {
-  test('ensures at most one quest in deck', () => {
-    const hero = { id: 'h1', name: 'Hero', type: 'hero', text: '', data: { armor: 0 } };
-    const quest1 = { id: 'q1', name: 'Quest1', type: 'quest', text: '' };
-    const quest2 = { id: 'q2', name: 'Quest2', type: 'quest', text: '' };
-    const ally = { id: 'a1', name: 'Ally', type: 'ally', text: '', cost: 1, data: { attack: 1, health: 1 } };
-    const allCards = [hero, quest1, quest2, ally];
-    const state = { hero, cards: [quest1, quest2] };
+  test('enforces deck building constraints', () => {
+    const { hero, quests, allies, equipments, spells, allCards } = buildAllCards();
+    const state = {
+      hero,
+      cards: [
+        ...quests,
+        ...Array(4).fill(allies[0]),
+        equipments[0],
+        equipments[1],
+        equipments[1],
+        equipments[1],
+        spells[0],
+        spells[1],
+      ],
+    };
+
     fillDeckRandomly(state, allCards, new RNG(1));
-    const quests = state.cards.filter(c => c.type === 'quest');
-    expect(quests).toHaveLength(1);
+
+    expect(state.hero).toBe(hero);
     expect(state.cards).toHaveLength(60);
+    expect(state.cards.every(card => card.type !== 'quest')).toBe(true);
+
+    const counts = state.cards.reduce((acc, card) => {
+      acc[card.id] = (acc[card.id] || 0) + 1;
+      return acc;
+    }, {});
+    Object.values(counts).forEach(count => {
+      expect(count).toBeLessThanOrEqual(3);
+    });
+
+    const equipmentCards = state.cards.filter(card => card.type === 'equipment');
+    const equipmentIds = new Set(equipmentCards.map(card => card.id));
+    expect(equipmentIds.size).toBeLessThanOrEqual(1);
+    if (equipmentCards.length > 0) {
+      expect(equipmentCards.length).toBeLessThanOrEqual(3);
+    }
+
+    const allyCount = state.cards.filter(card => card.type === 'ally').length;
+    expect(allyCount).toBeGreaterThanOrEqual(30);
+  });
+
+  test('assigns hero when missing and fills to 60 cards', () => {
+    const { allCards } = buildAllCards();
+    const state = { hero: null, cards: [] };
+
+    fillDeckRandomly(state, allCards, new RNG(2));
+
+    expect(state.hero?.type).toBe('hero');
+    expect(state.cards).toHaveLength(60);
+    const allyCount = state.cards.filter(card => card.type === 'ally').length;
+    expect(allyCount).toBeGreaterThanOrEqual(30);
   });
 });
 

--- a/src/js/utils/deckbuilder.js
+++ b/src/js/utils/deckbuilder.js
@@ -8,33 +8,103 @@ export function fillDeckRandomly(state, allCards, rng = null) {
   const pick = rng instanceof RNG ? (arr) => rng.pick(arr) : (arr) => defaultPick(arr);
 
   const heroes = allCards.filter(c => c.type === 'hero');
-  const quests = allCards.filter(c => c.type === 'quest');
-  const others = allCards.filter(c => c.type !== 'hero' && c.type !== 'quest');
-
   if (!state.hero) {
     if (heroes.length === 0) return state;
     state.hero = pick(heroes);
   }
 
-  // ensure at most one quest is present in the deck state
-  let questSeen = false;
-  for (let i = state.cards.length - 1; i >= 0; i--) {
-    const card = state.cards[i];
-    if (card.type === 'quest') {
-      if (questSeen) state.cards.splice(i, 1);
-      else questSeen = true;
+  if (!Array.isArray(state.cards)) state.cards = [];
+
+  const counts = new Map();
+  let equipmentId = null;
+  const sanitized = [];
+
+  for (const card of state.cards) {
+    if (!card || card.type === 'quest') continue;
+    if (card.type === 'equipment') {
+      if (!equipmentId) equipmentId = card.id;
+      if (card.id !== equipmentId) continue;
+    }
+    const current = counts.get(card.id) || 0;
+    if (current >= 3) continue;
+    counts.set(card.id, current + 1);
+    sanitized.push(card);
+  }
+
+  state.cards = sanitized;
+  let allyCount = sanitized.filter(c => c.type === 'ally').length;
+
+  const removeCardAt = (index) => {
+    if (index < 0 || index >= state.cards.length) return null;
+    const [removed] = state.cards.splice(index, 1);
+    if (!removed) return null;
+    const current = counts.get(removed.id) || 0;
+    if (current <= 1) counts.delete(removed.id);
+    else counts.set(removed.id, current - 1);
+    if (removed.type === 'ally') allyCount = Math.max(0, allyCount - 1);
+    if (removed.type === 'equipment' && !counts.has(removed.id)) equipmentId = null;
+    return removed;
+  };
+
+  const requiredAllies = Math.max(0, 30 - allyCount);
+  const spaceAvailable = 60 - state.cards.length;
+  let neededSlots = requiredAllies - spaceAvailable;
+  if (neededSlots < 0) neededSlots = 0;
+
+  if (neededSlots > 0) {
+    for (let i = state.cards.length - 1; i >= 0 && neededSlots > 0; i--) {
+      const card = state.cards[i];
+      if (card && card.type !== 'ally') {
+        removeCardAt(i);
+        neededSlots -= 1;
+      }
     }
   }
 
-  while (state.cards.length < 60) {
-    const pool = questSeen ? others : others.concat(quests);
-    if (pool.length === 0) break;
-    const card = pick(pool);
+  const allyCards = allCards.filter(c => c.type === 'ally');
+  const nonQuestCards = allCards.filter(c => c.type !== 'hero' && c.type !== 'quest');
+
+  const canAdd = (card) => {
+    if (!card || card.type === 'quest' || card.type === 'hero') return false;
+    const current = counts.get(card.id) || 0;
+    if (current >= 3) return false;
+    if (card.type === 'equipment') {
+      if (equipmentId && card.id !== equipmentId) return false;
+    }
+    return true;
+  };
+
+  const addCard = (card) => {
     state.cards.push(card);
-    if (card.type === 'quest') questSeen = true;
+    counts.set(card.id, (counts.get(card.id) || 0) + 1);
+    if (card.type === 'equipment' && !equipmentId) equipmentId = card.id;
+    if (card.type === 'ally') allyCount += 1;
+  };
+
+  const pickEligible = (pool) => {
+    const eligible = pool.filter(canAdd);
+    if (eligible.length === 0) return null;
+    return pick(eligible);
+  };
+
+  while (allyCount < 30 && state.cards.length < 60) {
+    const card = pickEligible(allyCards);
+    if (!card) break;
+    addCard(card);
   }
 
-  if (state.cards.length > 60) state.cards.length = 60;
+  while (state.cards.length < 60) {
+    const card = pickEligible(nonQuestCards);
+    if (!card) break;
+    addCard(card);
+  }
+
+  while (state.cards.length > 60) {
+    let indexToRemove = state.cards.findIndex(c => c && c.type !== 'ally');
+    if (indexToRemove === -1) indexToRemove = state.cards.length - 1;
+    removeCardAt(indexToRemove);
+  }
+
   return state;
 }
 


### PR DESCRIPTION
## Summary
- enforce random deck builder constraints including removing quests, capping copies, and limiting equipment types while ensuring at least 30 allies
- add utility tests that validate the new deck-building rules
- update UI deck builder tests to use a larger card pool compatible with the stricter constraints

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cba2a206fc8323b58863259c58ea86