### PR TITLE
fix: enforce deckbuilder limits during training

### DIFF
--- a/__tests__/game.training-deck.test.js
+++ b/__tests__/game.training-deck.test.js
@@ -1,0 +1,40 @@
+import Game from '../src/js/game.js';
+import { RNG } from '../src/js/utils/rng.js';
+
+describe('training decks', () => {
+  function expectDeckToRespectLimits(cards) {
+    expect(Array.isArray(cards)).toBe(true);
+    expect(cards).toHaveLength(60);
+
+    const counts = new Map();
+    const equipmentIds = new Set();
+    let allyCount = 0;
+
+    for (const card of cards) {
+      expect(card).toBeTruthy();
+      const prev = counts.get(card.id) || 0;
+      const next = prev + 1;
+      counts.set(card.id, next);
+      expect(next).toBeLessThanOrEqual(3);
+      if (card.type === 'ally') allyCount += 1;
+      if (card.type === 'equipment') equipmentIds.add(card.id);
+      expect(card.type).not.toBe('quest');
+    }
+
+    expect(allyCount).toBeGreaterThanOrEqual(30);
+    expect(equipmentIds.size).toBeLessThanOrEqual(1);
+  }
+
+  it('use deckbuilder random fill limits for AI training decks', async () => {
+    const game = new Game(null, { aiPlayers: ['player', 'opponent'] });
+    game.rng = new RNG(1234);
+    await game.setupMatch();
+
+    expect(game.player.hero).toBeTruthy();
+    expect(game.opponent.hero).toBeTruthy();
+    const playerDeckCards = [...game.player.library.cards, ...game.player.hand.cards];
+    const opponentDeckCards = [...game.opponent.library.cards, ...game.opponent.hand.cards];
+    expectDeckToRespectLimits(playerDeckCards);
+    expectDeckToRespectLimits(opponentDeckCards);
+  });
+});


### PR DESCRIPTION
## Summary
- reuse the deckbuilder random fill when creating AI decks so training matches respect card limits and hero uniqueness
- retry fills to ensure 60-card decks before falling back to legacy sanitization logic
- add a regression test that confirms training decks meet the deckbuilder constraints

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cba769de148323a80c5f2c5808d7e9