### PR TITLE
feat: teach MCTS AI explicit attack handling

### DIFF
--- a/src/js/systems/ai-signatures.js
+++ b/src/js/systems/ai-signatures.js
@@ -23,9 +23,20 @@ export function cardSignature(card) {
 export function actionSignature(action) {
   if (!action) return 'noop';
   const cardPart = action.card ? cardSignature(action.card) : 'no-card';
+  let attackPart = 'attack:none';
+  if (action.attack) {
+    const attackerId = action.attack.attackerId
+      || action.attack.attacker?.id
+      || 'unknown';
+    const rawTarget = action.attack.targetId
+      ?? action.attack.target?.id
+      ?? null;
+    const targetPart = rawTarget == null ? 'face' : rawTarget;
+    attackPart = `attack:${attackerId}->${targetPart}`;
+  }
   const usePower = action.usePower ? 'power:1' : 'power:0';
   const end = action.end ? 'end:1' : 'end:0';
-  return `${cardPart}|${usePower}|${end}`;
+  return `${cardPart}|${attackPart}|${usePower}|${end}`;
 }
 
 export default actionSignature;


### PR DESCRIPTION
## Summary
- track entered-this-turn state on live and simulated MCTS nodes so attack readiness stays accurate
- add explicit attack actions throughout heuristic and full simulations and apply them directly during takeTurn
- encode attack choices in action signatures and add tests for lethal and taunt-clearing attack sequences

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc331815d083238be3bdf69375f263