### PR TITLE
Improve MCTS target selection for single-target effects

### DIFF
--- a/__tests__/combat.taunt.test.js
+++ b/__tests__/combat.taunt.test.js
@@ -1,0 +1,57 @@
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+
+function setupGameWithTauntDefender() {
+  const game = new Game(null, { aiPlayers: [] });
+  const { player, opponent } = game;
+
+  player.hero = new Hero({ id: 'player-hero', name: 'Garrosh', data: { attack: 0, health: 30 } });
+  opponent.hero = new Hero({ id: 'ai-hero', name: 'Illidan', data: { attack: 0, health: 30 } });
+  player.hero.owner = player;
+  opponent.hero.owner = opponent;
+
+  const grunt = new Card({
+    id: 'grunt',
+    name: 'Orgrimmar Grunt',
+    type: 'ally',
+    keywords: ['Taunt'],
+    data: { attack: 2, health: 2 },
+  });
+  grunt.owner = player;
+  player.battlefield.add(grunt);
+
+  const attacker = new Card({
+    id: 'footman',
+    name: 'Stormwind Footman',
+    type: 'ally',
+    data: { attack: 1, health: 2, attacked: false, summoningSick: false, attacksUsed: 0 },
+  });
+  attacker.owner = opponent;
+  opponent.battlefield.add(attacker);
+
+  return { game, player, opponent, grunt, attacker };
+}
+
+describe('combat taunt enforcement', () => {
+  test('attacks targeting the hero are redirected to an available taunt defender', async () => {
+    const { game, player, opponent, grunt, attacker } = setupGameWithTauntDefender();
+
+    const result = await game.attack(opponent, attacker.id, player.hero.id);
+
+    expect(result).toBe(true);
+    expect(player.hero.data.health).toBe(30);
+    expect(grunt.data.health).toBe(1);
+  });
+
+  test('attacks succeed when the taunt defender is targeted', async () => {
+    const { game, player, opponent, grunt, attacker } = setupGameWithTauntDefender();
+
+    const result = await game.attack(opponent, attacker.id, grunt.id);
+
+    expect(result).toBe(true);
+    expect(player.hero.data.health).toBe(30);
+    expect(grunt.data.health).toBe(1);
+  });
+});
+

--- a/src/js/systems/ai-signatures.js
+++ b/src/js/systems/ai-signatures.js
@@ -36,7 +36,10 @@ export function actionSignature(action) {
   }
   const usePower = action.usePower ? 'power:1' : 'power:0';
   const end = action.end ? 'end:1' : 'end:0';
-  return `${cardPart}|${attackPart}|${usePower}|${end}`;
+  const targets = (typeof action.__mctsTargetSignature === 'string' && action.__mctsTargetSignature.length)
+    ? `targets:${action.__mctsTargetSignature}`
+    : 'targets:none';
+  return `${cardPart}|${attackPart}|${usePower}|${end}|${targets}`;
 }
 
 export default actionSignature;


### PR DESCRIPTION
## Summary
- add helpers to enumerate legal friendly and enemy characters so damage targeting accounts for taunt, stealth and source exclusions
- branch MCTS simple effect handling by candidate target, cloning state to score options and recording target choices in the action signature
- extend action signatures with serialized target selections and cover the behaviour with a unit test that prefers removing the largest threat

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc3de91a688323afabfe9e251a4367