### PR TITLE
feat: improve basic ai combat targeting

### DIFF
--- a/__tests__/ai.combat-trade.test.js
+++ b/__tests__/ai.combat-trade.test.js
@@ -1,0 +1,37 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+import BasicAI from '../src/js/systems/ai.js';
+
+function containsCard(zone, id) {
+  return zone.cards.some(c => c?.id === id);
+}
+
+test('AI trades a smaller ally into a dangerous threat', () => {
+  const g = new Game();
+  const ai = new BasicAI({ resourceSystem: g.resources, combatSystem: g.combat });
+
+  g.turns.turn = 5;
+  g.player.library.cards = [];
+  g.opponent.library.cards = [];
+
+  const threat = new Card({ name: 'Sinister Ravager', type: 'ally', data: { attack: 5, health: 2 } });
+  const fodder = new Card({ name: 'Loyal Grunt', type: 'ally', data: { attack: 2, health: 2 } });
+
+  threat.owner = g.opponent;
+  fodder.owner = g.player;
+  fodder.data.attacked = false;
+  threat.data.attacked = false;
+
+  g.player.battlefield.cards = [fodder];
+  g.opponent.battlefield.cards = [threat];
+
+  const startingEnemyHealth = g.opponent.hero.data.health;
+
+  g.turns.setActivePlayer(g.player);
+  ai.takeTurn(g.player, g.opponent);
+
+  expect(containsCard(g.opponent.graveyard, threat.id)).toBe(true);
+  expect(containsCard(g.player.graveyard, fodder.id)).toBe(true);
+  expect(containsCard(g.opponent.battlefield, threat.id)).toBe(false);
+  expect(g.opponent.hero.data.health).toBe(startingEnemyHealth);
+});


### PR DESCRIPTION
## Summary
- add combat evaluation helpers so the basic AI picks between attacking the hero or trading into specific allies
- ensure simulated and real combat phases assign blockers for chosen trades and track freshly played ally entry turns
- add a regression test that asserts the basic AI trades a weaker ally into a high-attack threat

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cd18d46b488323b63ecbc63fc40069