### PR TITLE
feat: include action targets in combat log

### DIFF
--- a/__tests__/combat-log.targets.test.js
+++ b/__tests__/combat-log.targets.test.js
@@ -1,0 +1,52 @@
+/** @jest-environment jsdom */
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+
+const heroCards = JSON.parse(
+  fs.readFileSync(new URL('../data/cards/hero.json', import.meta.url).pathname)
+);
+const thrallData = heroCards.find(c => c.id === 'hero-thrall-warchief-of-the-horde');
+
+const spellCards = JSON.parse(
+  fs.readFileSync(new URL('../data/cards/spell.json', import.meta.url).pathname)
+);
+const powerWordShield = spellCards.find(c => c.id === 'spell-power-word-shield');
+
+const allyCards = JSON.parse(
+  fs.readFileSync(new URL('../data/cards/ally.json', import.meta.url).pathname)
+);
+const waterElementalGuardian = allyCards.find(c => c.id === 'ally-water-elemental-guardian');
+
+if (!thrallData || !powerWordShield || !waterElementalGuardian) {
+  throw new Error('Required card data missing for combat log tests.');
+}
+
+test('logs targeted actions when playing a spell', async () => {
+  const g = new Game();
+  g.player.hero = new Hero(thrallData);
+  g.player.hero.owner = g.player;
+  g.opponent.hero = new Hero(thrallData);
+  g.opponent.hero.owner = g.opponent;
+
+  const target = new Card(waterElementalGuardian);
+  target.owner = g.player;
+  g.player.battlefield.add(target);
+
+  const spell = new Card(powerWordShield);
+  spell.owner = g.player;
+  g.player.hand.add(spell);
+
+  g.turns.setActivePlayer(g.player);
+  g.turns.turn = 5;
+  g.resources.startTurn(g.player);
+
+  g.promptTarget = async () => target;
+
+  const ok = await g.playFromHand(g.player, spell);
+  expect(ok).toBe(true);
+
+  const lastLog = g.player.log[g.player.log.length - 1];
+  expect(lastLog).toBe(`Played ${spell.name} targeting ${target.name}`);
+});

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -322,6 +322,7 @@ export class EffectSystem {
     }
 
     for (const t of actualTargets) {
+      if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(t);
       // Divine Shield absorbs one instance of damage (for shielded minions)
       if (t?.data?.divineShield) {
         t.data.divineShield = false;
@@ -652,6 +653,7 @@ export class EffectSystem {
     }
 
     for (const t of actualTargets) {
+      if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(t);
       // Determine max health with sensible fallbacks (heroes default to 30)
       const cur = t?.data?.health ?? t?.health;
       const max = (t?.data?.maxHealth ?? t?.maxHealth ?? (t?.type === 'hero' ? 30 : cur));
@@ -1193,6 +1195,7 @@ export class EffectSystem {
       return;
     }
 
+    if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(chosen);
     owner.battlefield.moveTo(owner.graveyard, chosen);
     console.log(`Destroyed ${chosen.name}.`);
   }
@@ -1238,6 +1241,7 @@ export class EffectSystem {
                 : null;
     if (!owner) return;
 
+    if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(chosen);
     owner.battlefield.moveTo(owner.hand, chosen);
     chosen.cost = (chosen.cost || 0) + costIncrease;
     console.log(`Returned ${chosen.name} to hand. New cost: ${chosen.cost}`);
@@ -1401,6 +1405,7 @@ export class EffectSystem {
 
     if (pool.length > 0) {
       const allyToTransform = game.rng.pick(pool);
+      if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(allyToTransform);
       const originalData = { ...allyToTransform.data };
       const originalKeywords = [...(allyToTransform.keywords || [])];
       const originalName = allyToTransform.name; // Store original name
@@ -1503,6 +1508,7 @@ export class EffectSystem {
     }
 
     for (const t of actualTargets) {
+      if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(t);
       const scheduleRevert = (revertFn) => {
         if (!duration) return;
         if (duration === 'thisTurn') {


### PR DESCRIPTION
## Summary
- track action targets during card plays and hero powers so combat log entries list chosen targets
- record selected targets across major effect handlers to capture automatic or prompted targeting
- add a regression test that exercises a targeted spell and verifies the combat log output

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd64f4ca088323a7e9fef608ed8061