### PR TITLE
fix: ensure auto-targeted spells log targets

### DIFF
--- a/__tests__/combat-log.targets.test.js
+++ b/__tests__/combat-log.targets.test.js
@@ -1,5 +1,7 @@
 /** @jest-environment jsdom */
 import fs from 'fs';
+import { jest } from '@jest/globals';
+import { fileURLToPath } from 'url';
 import Game from '../src/js/game.js';
 import Hero from '../src/js/entities/hero.js';
 import Card from '../src/js/entities/card.js';
@@ -13,15 +15,45 @@ const spellCards = JSON.parse(
   fs.readFileSync(new URL('../data/cards/spell.json', import.meta.url).pathname)
 );
 const powerWordShield = spellCards.find(c => c.id === 'spell-power-word-shield');
+const shadowWordPain = spellCards.find(c => c.id === 'spell-shadow-word-pain');
 
 const allyCards = JSON.parse(
   fs.readFileSync(new URL('../data/cards/ally.json', import.meta.url).pathname)
 );
 const waterElementalGuardian = allyCards.find(c => c.id === 'ally-water-elemental-guardian');
 
-if (!thrallData || !powerWordShield || !waterElementalGuardian) {
+if (!thrallData || !powerWordShield || !shadowWordPain || !waterElementalGuardian) {
   throw new Error('Required card data missing for combat log tests.');
 }
+
+const originalFetch = global.fetch;
+
+beforeAll(() => {
+  global.fetch = async (input) => {
+    try {
+      const url = typeof input === 'string' ? new URL(input, import.meta.url) : input;
+      const path = fileURLToPath(url);
+      const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+      return {
+        ok: true,
+        async json() {
+          return data;
+        },
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        async json() {
+          throw err;
+        },
+      };
+    }
+  };
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
 
 test('logs targeted actions when playing a spell', async () => {
   const g = new Game();
@@ -49,4 +81,114 @@ test('logs targeted actions when playing a spell', async () => {
 
   const lastLog = g.player.log[g.player.log.length - 1];
   expect(lastLog).toBe(`Played ${spell.name} targeting ${target.name}`);
+});
+
+test('auto-selected destroy effects still log their target', async () => {
+  const g = new Game();
+  await g.setupMatch();
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.hand.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.player.hero = new Hero(thrallData);
+  g.player.hero.owner = g.player;
+  g.opponent.hero = new Hero(thrallData);
+  g.opponent.hero.owner = g.opponent;
+
+  const enemy = new Card(waterElementalGuardian);
+  enemy.owner = g.opponent;
+  g.opponent.battlefield.add(enemy);
+
+  const spell = new Card(shadowWordPain);
+  spell.owner = g.player;
+  g.player.hand.add(spell);
+
+  g.turns.setActivePlayer(g.player);
+  g.turns.turn = 5;
+  g.resources.startTurn(g.player);
+
+  const formatSpy = jest.spyOn(g, '_formatLogWithTargets');
+  const ok = await g.playFromHand(g.player, spell);
+  expect(ok).toBe(true);
+
+  expect(formatSpy).toHaveBeenCalled();
+  const [, targets] = formatSpy.mock.calls[formatSpy.mock.calls.length - 1];
+  expect(targets).toContain(enemy);
+  formatSpy.mockRestore();
+
+  const lastLog = g.player.log[g.player.log.length - 1];
+  expect(lastLog).toBe(`Played ${spell.name} targeting ${enemy.name}`);
+});
+
+test('AI auto-selected destroy effects log their target', async () => {
+  const g = new Game();
+  await g.setupMatch();
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.hand.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.player.hero = new Hero(thrallData);
+  g.player.hero.owner = g.player;
+  g.opponent.hero = new Hero(thrallData);
+  g.opponent.hero.owner = g.opponent;
+
+  const target = new Card(waterElementalGuardian);
+  target.owner = g.player;
+  g.player.battlefield.add(target);
+
+  const spell = new Card(shadowWordPain);
+  spell.owner = g.opponent;
+  g.opponent.hand.add(spell);
+
+  g.turns.setActivePlayer(g.opponent);
+  g.turns.turn = 5;
+  g.resources.startTurn(g.opponent);
+
+  const formatSpy = jest.spyOn(g, '_formatLogWithTargets');
+  const ok = await g.playFromHand(g.opponent, spell);
+  expect(ok).toBe(true);
+
+  expect(formatSpy).toHaveBeenCalled();
+  const [, targets] = formatSpy.mock.calls[formatSpy.mock.calls.length - 1];
+  expect(targets).toContain(target);
+  formatSpy.mockRestore();
+
+  const lastLog = g.opponent.log[g.opponent.log.length - 1];
+  expect(lastLog).toBe(`Played ${spell.name} targeting ${target.name}`);
+});
+
+test('auto-target logging falls back when target capture is unavailable', async () => {
+  const g = new Game();
+  await g.setupMatch();
+  g.player.hand.cards = [];
+  g.player.battlefield.cards = [];
+  g.opponent.hand.cards = [];
+  g.opponent.battlefield.cards = [];
+  g.player.hero = new Hero(thrallData);
+  g.player.hero.owner = g.player;
+  g.opponent.hero = new Hero(thrallData);
+  g.opponent.hero.owner = g.opponent;
+
+  const enemy = new Card(waterElementalGuardian);
+  enemy.owner = g.opponent;
+  g.opponent.battlefield.add(enemy);
+
+  const spell = new Card(shadowWordPain);
+  spell.owner = g.player;
+  g.player.hand.add(spell);
+
+  g.turns.setActivePlayer(g.player);
+  g.turns.turn = 5;
+  g.resources.startTurn(g.player);
+
+  const originalRecord = g.recordActionTarget;
+  g.recordActionTarget = () => {};
+
+  const ok = await g.playFromHand(g.player, spell);
+  expect(ok).toBe(true);
+
+  g.recordActionTarget = originalRecord;
+
+  const lastLog = g.player.log[g.player.log.length - 1];
+  expect(lastLog).toBe(`Played ${spell.name} targeting ${enemy.name}`);
 });

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -21,6 +21,21 @@ export class EffectSystem {
     });
   }
 
+  _recordTarget(context, target) {
+    if (!target) return;
+    const record = context?.recordLogTarget;
+    if (typeof record === 'function') {
+      try {
+        record(target);
+        return;
+      } catch {}
+    }
+    const game = context?.game;
+    if (game && typeof game.recordActionTarget === 'function') {
+      game.recordActionTarget(target);
+    }
+  }
+
   _trackCleanup(off) {
     if (typeof off !== 'function') return off;
     let active = true;
@@ -322,7 +337,7 @@ export class EffectSystem {
     }
 
     for (const t of actualTargets) {
-      if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(t);
+      this._recordTarget(context, t);
       // Divine Shield absorbs one instance of damage (for shielded minions)
       if (t?.data?.divineShield) {
         t.data.divineShield = false;
@@ -653,7 +668,7 @@ export class EffectSystem {
     }
 
     for (const t of actualTargets) {
-      if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(t);
+      this._recordTarget(context, t);
       // Determine max health with sensible fallbacks (heroes default to 30)
       const cur = t?.data?.health ?? t?.health;
       const max = (t?.data?.maxHealth ?? t?.maxHealth ?? (t?.type === 'hero' ? 30 : cur));
@@ -1195,7 +1210,7 @@ export class EffectSystem {
       return;
     }
 
-    if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(chosen);
+    this._recordTarget(context, chosen);
     owner.battlefield.moveTo(owner.graveyard, chosen);
     console.log(`Destroyed ${chosen.name}.`);
   }
@@ -1241,7 +1256,7 @@ export class EffectSystem {
                 : null;
     if (!owner) return;
 
-    if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(chosen);
+    this._recordTarget(context, chosen);
     owner.battlefield.moveTo(owner.hand, chosen);
     chosen.cost = (chosen.cost || 0) + costIncrease;
     console.log(`Returned ${chosen.name} to hand. New cost: ${chosen.cost}`);
@@ -1405,7 +1420,7 @@ export class EffectSystem {
 
     if (pool.length > 0) {
       const allyToTransform = game.rng.pick(pool);
-      if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(allyToTransform);
+      this._recordTarget(context, allyToTransform);
       const originalData = { ...allyToTransform.data };
       const originalKeywords = [...(allyToTransform.keywords || [])];
       const originalName = allyToTransform.name; // Store original name
@@ -1508,7 +1523,7 @@ export class EffectSystem {
     }
 
     for (const t of actualTargets) {
-      if (typeof game?.recordActionTarget === 'function') game.recordActionTarget(t);
+      this._recordTarget(context, t);
       const scheduleRevert = (revertFn) => {
         if (!duration) return;
         if (duration === 'thisTurn') {


### PR DESCRIPTION
## Summary
- capture auto-selected targets via a new recordLogTarget hook and fall back to them when combat log capture is empty
- update the effect system to use the shared target recorder so auto-targeted destroy/transform effects still surface targets
- add combat log regression tests covering auto-selection and fallback behaviour

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd8b3fefdc8323a81a81e2f54d538d