### PR TITLE
Implement ally reflect effect and Thorns spell

### DIFF
--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -424,6 +424,23 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         if (effect.keywords?.includes('Rush')) expect(beast.keywords).toContain('Rush');
         break;
       }
+      case 'grantKeyword': {
+        const ally = new Card({ name: 'Keyword Target', type: 'ally', data: { attack: 2, health: 3 }, keywords: [] });
+        g.player.battlefield.add(ally);
+        g.promptTarget = async () => ally;
+        await g.playFromHand(g.player, card.id);
+        expect(ally.keywords).toContain(effect.keyword);
+        if (effect.duration === 'untilYourNextTurn') {
+          g.turns.bus.emit('turn:start', { player: g.opponent });
+          expect(ally.keywords).toContain(effect.keyword);
+          g.turns.bus.emit('turn:start', { player: g.player });
+          expect(ally.keywords).not.toContain(effect.keyword);
+        } else if (effect.duration === 'thisTurn') {
+          g.effects.cleanupTemporaryEffects();
+          expect(ally.keywords).not.toContain(effect.keyword);
+        }
+        break;
+      }
       case 'buffTribe': {
         const tribe = effect.tribe || 'Murloc';
         const friendly = new Card({

--- a/__tests__/combat.reflect.test.js
+++ b/__tests__/combat.reflect.test.js
@@ -64,4 +64,30 @@ describe('Combat reflection from player equipment', () => {
     expect(player.hero.equipment.length).toBe(0);
     expect(player.graveyard.cards).toContain(weapon);
   });
+
+  test('ally with Reflect retaliates with attack plus received damage', () => {
+    const attacker = new Card({ id: 'attacker', name: 'Enemy Raider', type: 'ally', data: { attack: 4, health: 5 } });
+    const defender = new Card({
+      id: 'defender',
+      name: 'Thorned Guardian',
+      type: 'ally',
+      data: { attack: 3, health: 3 },
+      keywords: ['Reflect'],
+    });
+
+    const combat = new CombatSystem();
+    expect(combat.declareAttacker(attacker)).toBe(true);
+    combat.assignBlocker(attacker.id, defender);
+    const events = combat.resolve();
+
+    // Defender takes lethal damage but still reflects
+    expect(defender.data.health).toBe(0);
+    expect(defender.data.dead).toBe(true);
+    expect(attacker.data.health).toBe(0);
+    expect(attacker.data.dead).toBe(true);
+
+    const reflectEvents = events.filter(ev => ev.source === defender && ev.target === attacker && ev.isReflect);
+    expect(reflectEvents).toHaveLength(1);
+    expect(reflectEvents[0].amount).toBe(7);
+  });
 });

--- a/__tests__/spell.thorns.reflect.test.js
+++ b/__tests__/spell.thorns.reflect.test.js
@@ -1,0 +1,48 @@
+import { describe, test, expect } from '@jest/globals';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+describe('Thorns reflect effect', () => {
+  test('Thorns grants temporary reflect that triggers retaliation', async () => {
+    const g = new Game();
+    await g.setupMatch();
+
+    g.player.battlefield.cards = [];
+    g.opponent.battlefield.cards = [];
+    g.resources._pool.set(g.player, 10);
+    g.resources._pool.set(g.opponent, 10);
+
+    const defender = new Card({ id: 'defender', name: 'Target', type: 'ally', data: { attack: 2, health: 3 }, keywords: [] });
+    const attacker = new Card({ id: 'attacker', name: 'Enemy', type: 'ally', data: { attack: 3, health: 6 }, keywords: [] });
+
+    g.player.battlefield.add(defender);
+    g.opponent.battlefield.add(attacker);
+
+    g.addCardToHand('spell-thorns');
+    g.promptTarget = async () => defender;
+    await g.playFromHand(g.player, 'spell-thorns');
+
+    expect(defender.keywords).toContain('Reflect');
+
+    // Opponent turn start - effect should persist
+    g.turns.bus.emit('turn:start', { player: g.opponent });
+    expect(defender.keywords).toContain('Reflect');
+
+    const combat = g.combat;
+    expect(combat.declareAttacker(attacker)).toBe(true);
+    combat.assignBlocker(attacker.id, defender);
+    const events = combat.resolve();
+
+    const reflectEvents = events.filter(ev => ev.source === defender && ev.target === attacker && ev.isReflect);
+    expect(reflectEvents).toHaveLength(1);
+    expect(reflectEvents[0].amount).toBe(5);
+    expect(attacker.data.health).toBe(0);
+    expect(attacker.data.dead).toBe(true);
+    expect(defender.data.health).toBe(0);
+    expect(defender.data.dead).toBe(true);
+
+    // Start of player's next turn removes temporary keyword
+    g.turns.bus.emit('turn:start', { player: g.player });
+    expect(defender.keywords).not.toContain('Reflect');
+  });
+});

--- a/data/cards/spell.json
+++ b/data/cards/spell.json
@@ -927,8 +927,11 @@
     "cost": 1,
     "effects": [
       {
-        "type": "rawText",
-        "text": "Give a character ‘Damage Reflect (1) this turn.’"
+        "type": "grantKeyword",
+        "target": "character",
+        "allowHero": false,
+        "keyword": "Reflect",
+        "duration": "untilYourNextTurn"
       }
     ],
     "keywords": [
@@ -936,7 +939,7 @@
       "Buff"
     ],
     "data": {},
-    "text": "Give a character ‘Damage Reflect (1) this turn.’",
+    "text": "Give an ally ‘Damage Reflect (1)’ until your next turn.",
     "prompt": "Barbed vines coil around a guardian, spikes poised to lash at attackers."
   }
 ]

--- a/src/js/entities/card.js
+++ b/src/js/entities/card.js
@@ -19,6 +19,7 @@ export class CardEntity {
     // Copy common top-level stats for non-ally types (e.g., equipment)
     if (props.attack != null) this.attack = props.attack;
     if (props.durability != null) this.durability = props.durability;
+    this.baseKeywords = props.keywords ? Array.from(props.keywords) : [];
     this.keywords = props.keywords ? Array.from(props.keywords) : [];
     this.data = props.data ? { ...props.data } : {};
     // Ensure allies and other characters have a stable maxHealth baseline

--- a/src/js/systems/combat.js
+++ b/src/js/systems/combat.js
@@ -236,6 +236,27 @@ export class CombatSystem {
       }
       if (ev.source?.keywords?.includes?.('Freeze') && newHp > 0) freezeTarget(ev.target, 1);
       if (newHp <= 0) setStat(ev.target, 'dead', true);
+
+      if (!ev.isReflect && ev.amount > 0) {
+        const tgt = ev.target;
+        const src = ev.source;
+        const hasKeywordReflect = tgt?.keywords?.includes?.('Reflect');
+        const tempReflectCount = tgt?.data?.tempKeywordCounts?.Reflect || 0;
+        const targetIsReflectiveAlly = tgt?.type === 'ally' && (hasKeywordReflect || tempReflectCount > 0);
+        const sourceIsCharacter = src && (src.type === 'ally' || src.type === 'hero');
+        if (targetIsReflectiveAlly && sourceIsCharacter && src !== tgt) {
+          const attackValue = getStat(tgt, 'attack', 0);
+          const reflectAmount = Math.max(0, attackValue + ev.amount);
+          if (reflectAmount > 0) {
+            events.push({
+              target: src,
+              amount: reflectAmount,
+              source: tgt,
+              isReflect: true,
+            });
+          }
+        }
+      }
     }
 
     this.clear();


### PR DESCRIPTION
## Summary
- add ally reflect retaliation handling in combat and track base keywords on cards
- add a grantKeyword effect so Thorns can grant temporary Reflect and update the card data
- extend automated coverage for reflect scenarios and Thorns gameplay

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdbfa111588323b32c367bbe8fc77c