### PR TITLE
feat: randomize starting player order

### DIFF
--- a/__tests__/cancel.prompts.not-consume.test.js
+++ b/__tests__/cancel.prompts.not-consume.test.js
@@ -4,6 +4,8 @@ import Card from '../src/js/entities/card.js';
 test('canceling targeted spell prompt does not consume the card or mana', async () => {
   const g = new Game();
   await g.setupMatch();
+  g.turns.setActivePlayer(g.player);
+  g.turns.startTurn();
 
   // Setup: clear zones and give resources
   g.player.hand.cards = [];
@@ -30,6 +32,8 @@ test('canceling targeted spell prompt does not consume the card or mana', async 
 test('canceling choose-one prompt does not consume the card or mana', async () => {
   const g = new Game();
   await g.setupMatch();
+  g.turns.setActivePlayer(g.player);
+  g.turns.startTurn();
 
   // Use an ally with Choose One battlecry (Keeper of the Grove from cards-2)
   g.player.hand.cards = [];

--- a/__tests__/game.cards.test.js
+++ b/__tests__/game.cards.test.js
@@ -25,8 +25,10 @@ test('cards loaded with text for tooltips', async () => {
 test('players draw a card at the start of their turn', async () => {
   const g = new Game();
   await g.setupMatch();
-  expect(g.player.hand.size()).toBe(4);
   const before = g.player.hand.size();
+  if (g.turns.activePlayer !== g.player) {
+    g.turns.setActivePlayer(g.player);
+  }
   g.turns.startTurn();
   expect(g.player.hand.size()).toBe(before + 1);
 });

--- a/__tests__/game.deckbuilder.test.js
+++ b/__tests__/game.deckbuilder.test.js
@@ -19,8 +19,9 @@ test('starting new match clears previous hand and battlefield', async () => {
   const card = { id: 'a1', name: 'Ally', type: 'ally', text: '', data: { attack: 1, health: 1 } };
   const cards = Array(60).fill(card);
   await game.setupMatch({ hero, cards });
-  expect(game.player.hand.cards.length).toBe(4);
+  const playerStarts = game.turns.activePlayer === game.player;
+  expect(game.player.hand.cards.length).toBe(playerStarts ? 4 : 3);
   expect(game.player.battlefield.cards.length).toBe(0);
-  expect(game.opponent.hand.cards.length).toBe(3);
+  expect(game.opponent.hand.cards.length).toBe(playerStarts ? 3 : 4);
   expect(game.opponent.battlefield.cards.length).toBe(0);
 });

--- a/__tests__/game.starting-player.test.js
+++ b/__tests__/game.starting-player.test.js
@@ -32,4 +32,18 @@ describe('starting player selection', () => {
     const expected = key === 'player' ? game.player : game.opponent;
     expect(game.turns.activePlayer).toBe(expected);
   });
+
+  test('player gains only two resources on second turn when opponent starts', async () => {
+    const game = new Game(null, { aiPlayers: ['player', 'opponent'] });
+    game.rng = new RNG(1);
+    await game.setupMatch();
+    expect(game.state.startingPlayer).toBe('opponent');
+    expect(game.turns.turn).toBe(1);
+    expect(game.resources.pool(game.player)).toBe(1);
+
+    await game.endTurn();
+
+    expect(game.turns.turn).toBe(2);
+    expect(game.resources.pool(game.player)).toBe(2);
+  });
 });

--- a/__tests__/game.starting-player.test.js
+++ b/__tests__/game.starting-player.test.js
@@ -1,0 +1,35 @@
+import Game from '../src/js/game.js';
+import { RNG } from '../src/js/utils/rng.js';
+
+async function setupWithSeed(seed) {
+  const game = new Game(null, { aiPlayers: ['player', 'opponent'] });
+  game.rng = new RNG(seed);
+  await game.setupMatch();
+  return game;
+}
+
+describe('starting player selection', () => {
+  test('uses deterministic value for identical seeds', async () => {
+    const first = await setupWithSeed(1234);
+    const second = await setupWithSeed(1234);
+    expect(second.state.startingPlayer).toBe(first.state.startingPlayer);
+  });
+
+  test('varies across different seeds', async () => {
+    const seeds = Array.from({ length: 8 }, (_, i) => i + 1);
+    const results = [];
+    for (const seed of seeds) {
+      const game = await setupWithSeed(seed);
+      results.push(game.state.startingPlayer);
+    }
+    expect(new Set(results).size).toBeGreaterThan(1);
+  });
+
+  test('active player aligns with stored startingPlayer', async () => {
+    const game = await setupWithSeed(3456);
+    const key = game.state.startingPlayer;
+    expect(key === 'player' || key === 'opponent').toBe(true);
+    const expected = key === 'player' ? game.player : game.opponent;
+    expect(game.turns.activePlayer).toBe(expected);
+  });
+});

--- a/__tests__/healing-potion.targeting.test.js
+++ b/__tests__/healing-potion.targeting.test.js
@@ -5,6 +5,8 @@ import Card from '../src/js/entities/card.js';
 test('using Healing Potion prompts for target and respects enemy Taunt', async () => {
   const g = new Game();
   await g.setupMatch();
+  g.turns.setActivePlayer(g.player);
+  g.turns.startTurn();
 
   // Reset zones for determinism
   g.player.hand.cards = [];

--- a/__tests__/malfurion.hero-power.test.js
+++ b/__tests__/malfurion.hero-power.test.js
@@ -11,6 +11,7 @@ test("Malfurion's hero power offers a choice", async () => {
   await g.setupMatch();
   g.player.hero = new Hero(malfData);
   g.turns.turn = 2;
+  g.turns.setActivePlayer(g.player);
   g.resources.startTurn(g.player);
   const spy = jest.fn(async () => 0);
   g.promptOption = spy;
@@ -23,6 +24,7 @@ test("Malfurion's hero power can grant attack", async () => {
   await g.setupMatch();
   g.player.hero = new Hero(malfData);
   g.turns.turn = 2;
+  g.turns.setActivePlayer(g.player);
   g.resources.startTurn(g.player);
   g.promptOption = async () => 0; // choose attack option
   await g.useHeroPower(g.player);
@@ -36,6 +38,7 @@ test("Malfurion's hero power can grant armor", async () => {
   await g.setupMatch();
   g.player.hero = new Hero(malfData);
   g.turns.turn = 2;
+  g.turns.setActivePlayer(g.player);
   g.resources.startTurn(g.player);
   g.promptOption = async () => 1; // choose armor option
   await g.useHeroPower(g.player);

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -152,6 +152,7 @@ export default class Game {
     this._cardIndex = null;
     this._actionTargetStack = [];
     this._pendingTurnIncrement = false;
+    this._skipNextTurnAdvance = false;
   }
 
   setUIRerender(fn) {
@@ -1369,6 +1370,7 @@ export default class Game {
     if (this._pendingTurnIncrement) {
       this.turns.turn += 1;
       this._pendingTurnIncrement = false;
+      this._skipNextTurnAdvance = true;
     }
 
     await this._executeOpponentTurn();
@@ -1467,7 +1469,9 @@ export default class Game {
     while(this.turns.current !== 'End') {
       this.turns.nextPhase();
     }
-    if (preserveTurn) {
+    const skipAdvance = preserveTurn || this._skipNextTurnAdvance;
+    if (this._skipNextTurnAdvance) this._skipNextTurnAdvance = false;
+    if (skipAdvance) {
       const prev = this.turns.current;
       this.turns.bus.emit('phase:end', { phase: prev, turn: this.turns.turn });
       this.turns.setActivePlayer(this.player);
@@ -1503,6 +1507,7 @@ export default class Game {
     this.player = new Player({ name: 'You' });
     this.opponent = new Player({ name: 'AI' });
     this._pendingTurnIncrement = false;
+    this._skipNextTurnAdvance = false;
     await this.setupMatch(playerDeck);
   }
 

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -15,6 +15,7 @@ import { selectTargets } from './systems/targeting.js';
 import { logSecretTriggered } from './utils/combatLog.js';
 import { fillDeckRandomly } from './utils/deckbuilder.js';
 import { getCardInstanceId, matchesCardIdentifier } from './utils/card.js';
+import { chooseStartingPlayerKey } from './utils/turnOrder.js';
 
 const DEFAULT_AI_ACTION_DELAY_MS = 1000;
 
@@ -150,6 +151,7 @@ export default class Game {
     this._playerDeckTemplates = null;
     this._cardIndex = null;
     this._actionTargetStack = [];
+    this._pendingTurnIncrement = false;
   }
 
   setUIRerender(fn) {
@@ -332,6 +334,7 @@ export default class Game {
     const cardById = new Map(this.allCards.map((card) => [card.id, card]));
     this._cardIndex = cardById;
     this._playerDeckTemplates = null;
+    this._pendingTurnIncrement = false;
 
     const rng = this.rng;
     const createRandomDeckState = (excludeHeroId = null) => {
@@ -504,14 +507,25 @@ export default class Game {
     this.player.library.shuffle(rng);
     this.opponent.library.shuffle(rng);
 
+    const startingKey = chooseStartingPlayerKey(this.rng);
+    const startingPlayer = startingKey === 'player' ? this.player : this.opponent;
+    const waitingPlayer = startingKey === 'player' ? this.opponent : this.player;
+    if (this.state) {
+      this.state.startingPlayer = startingKey;
+    }
 
-
-    this.turns.setActivePlayer(this.player);
+    this.turns.setActivePlayer(startingPlayer);
     // Draw opening hand
-    this.draw(this.player, 3);
-    this.draw(this.opponent, 3);
+    this.draw(startingPlayer, 3);
+    this.draw(waitingPlayer, 3);
     this.turns.startTurn();
-    this.resources.startTurn(this.player);
+    this.resources.startTurn(startingPlayer);
+
+    if (startingPlayer === this.opponent
+      && this._isAIControlled(this.opponent)
+      && !this._isAIControlled(this.player)) {
+      await this._executeOpponentTurn({ skipSetup: true, preserveTurn: true });
+    }
 
     if (this.state?.difficulty === 'hybrid' || this.state?.difficulty === 'nightmare') {
       this._ensureNNModelLoading();
@@ -1216,6 +1230,117 @@ export default class Game {
     return true;
   }
 
+  async _executeOpponentTurn({ skipSetup = false, preserveTurn = false } = {}) {
+    if (!skipSetup) {
+      this.turns.setActivePlayer(this.opponent);
+      this.turns.startTurn();
+      this.resources.startTurn(this.opponent);
+    }
+
+    const diff = this.state?.difficulty || 'easy';
+    if (diff === 'nightmare' || diff === 'hybrid') {
+      this._ensureNNModelLoading();
+    }
+    if (diff === 'nightmare') {
+      const { default: NeuralAI, loadModelFromDiskOrFetch } = await import('./systems/ai-nn.js');
+      await loadModelFromDiskOrFetch();
+      const ai = new NeuralAI({ game: this, resourceSystem: this.resources, combatSystem: this.combat });
+      if (this.state) this.state.aiThinking = true;
+      this.bus.emit('ai:thinking', { thinking: true });
+      try {
+        await ai.takeTurn(this.opponent, this.player);
+      } finally {
+        if (this.state) this.state.aiThinking = false;
+        this.bus.emit('ai:thinking', { thinking: false });
+      }
+      if (this.isGameOver()) return;
+    } else if (diff === 'medium' || diff === 'hard' || diff === 'hybrid') {
+      if (this.state) this.state.aiPending = { type: 'mcts', stage: 'queued' };
+      const ai = await this._createMctsAI(diff);
+      if (this.state) this.state.aiThinking = true;
+      this.bus.emit('ai:thinking', { thinking: true });
+      try {
+        await ai.takeTurn(this.opponent, this.player);
+      } finally {
+        if (this.state) {
+          this.state.aiThinking = false;
+          this.state.aiPending = null;
+        }
+        this.bus.emit('ai:thinking', { thinking: false });
+      }
+      if (this.isGameOver()) return;
+    } else {
+      const affordable = this.opponent.hand.cards
+        .filter(c => this.canPlay(this.opponent, c))
+        .sort((a, b) => (a.cost || 0) - (b.cost || 0));
+      if (affordable[0]) {
+        await this.playFromHand(this.opponent, affordable[0]);
+        if (this.isGameOver()) return;
+      }
+      const attackers = this.opponent.battlefield.cards.filter((c) => {
+        if (!(c.type === 'ally' || c.type === 'equipment')) return false;
+        const atk = typeof c.totalAttack === 'function' ? c.totalAttack() : (c.data?.attack || 0);
+        const maxAttacks = c?.keywords?.includes?.('Windfury') ? 2 : 1;
+        const used = c?.data?.attacksUsed || 0;
+        return atk > 0 && !c?.data?.summoningSick && used < maxAttacks;
+      });
+      for (const c of attackers) {
+        if (this.isGameOver()) break;
+        const hasRush = !!c?.keywords?.includes?.('Rush');
+        const justEntered = !!(c?.data?.enteredTurn && c.data.enteredTurn === this.turns.turn);
+        const defenders = [
+          this.player.hero,
+          ...this.player.battlefield.cards.filter((d) => d.type !== 'equipment' && d.type !== 'quest')
+        ];
+        const legal = selectTargets(defenders);
+        if (hasRush && justEntered) {
+          const nonHero = legal.filter((t) => !matchesCardIdentifier(t, this.player.hero));
+          if (nonHero.length === 0) continue;
+        }
+        let block = null;
+        if (legal.length === 1) {
+          const only = legal[0];
+          if (!matchesCardIdentifier(only, this.player.hero)) block = only;
+        } else if (legal.length > 1) {
+          const choices = legal.filter((t) => !matchesCardIdentifier(t, this.player.hero));
+          block = this.rng.pick(choices);
+        }
+        const target = block || this.player.hero;
+        await this.throttleAIAction(this.opponent);
+        if (this.isGameOver()) break;
+        const declared = this.combat.declareAttacker(c, target);
+        if (!declared) continue;
+        if (c.data) {
+          c.data.attacked = true;
+          c.data.attacksUsed = (c.data.attacksUsed || 0) + 1;
+        }
+        if (c?.keywords?.includes?.('Stealth')) {
+          c.keywords = c.keywords.filter((k) => k !== 'Stealth');
+        }
+        if (block) this.combat.assignBlocker(getCardInstanceId(c), block);
+        this.opponent.log.push(`Attacked ${target.name} with ${c.name}`);
+      }
+      this.combat.setDefenderHero(this.player.hero);
+      const events = this.combat.resolve();
+      for (const ev of events) {
+        const srcOwner = [this.opponent.hero, ...this.opponent.battlefield.cards].includes(ev.source) ? this.opponent : this.player;
+        this.bus.emit('damageDealt', { player: srcOwner, source: ev.source, amount: ev.amount, target: ev.target });
+      }
+      if (this._uiRerender) {
+        try { this._uiRerender(); } catch {}
+      }
+      await this.cleanupDeaths(this.player, this.opponent);
+      await this.cleanupDeaths(this.opponent, this.player);
+      this.checkForGameOver();
+      if (this.isGameOver()) return;
+    }
+
+    if (this.isGameOver()) return;
+
+    await this._finalizeOpponentTurn({ preserveTurn });
+    if (preserveTurn) this._pendingTurnIncrement = true;
+  }
+
   async cleanupDeaths(player, killer) {
     const dead = player.battlefield.cards.filter(c => c.data?.dead);
     for (const c of dead) {
@@ -1241,122 +1366,12 @@ export default class Game {
 
     if (this.isGameOver()) return;
 
-    // AI's turn
-    this.turns.setActivePlayer(this.opponent);
-    this.turns.startTurn();
-    this.resources.startTurn(this.opponent);
-
-    const diff = this.state?.difficulty || 'easy';
-    if (diff === 'nightmare' || diff === 'hybrid') {
-      this._ensureNNModelLoading();
-    }
-    if (diff === 'nightmare') {
-      // Neural network AI (nightmare)
-      const { default: NeuralAI, loadModelFromDiskOrFetch } = await import('./systems/ai-nn.js');
-      // Lazy-load model if not already set
-      await loadModelFromDiskOrFetch();
-      const ai = new NeuralAI({ game: this, resourceSystem: this.resources, combatSystem: this.combat });
-      if (this.state) this.state.aiThinking = true;
-      this.bus.emit('ai:thinking', { thinking: true });
-      try {
-        await ai.takeTurn(this.opponent, this.player);
-      } finally {
-        if (this.state) this.state.aiThinking = false;
-        this.bus.emit('ai:thinking', { thinking: false });
-      }
-      if (this.isGameOver()) return;
-    } else if (diff === 'medium' || diff === 'hard' || diff === 'hybrid') {
-      // Use MCTS for medium/hard; hard uses deeper search
-      if (this.state) this.state.aiPending = { type: 'mcts', stage: 'queued' };
-      const ai = await this._createMctsAI(diff);
-      // Mark AI as thinking to allow UI to disable controls
-      if (this.state) this.state.aiThinking = true;
-      this.bus.emit('ai:thinking', { thinking: true });
-      try {
-        await ai.takeTurn(this.opponent, this.player);
-      } finally {
-        if (this.state) {
-          this.state.aiThinking = false;
-          this.state.aiPending = null;
-        }
-        this.bus.emit('ai:thinking', { thinking: false });
-      }
-      if (this.isGameOver()) return;
-    } else {
-      // Easy difficulty: previous simple heuristic flow
-      const affordable = this.opponent.hand.cards
-        .filter(c => this.canPlay(this.opponent, c))
-        .sort((a,b)=> (a.cost||0)-(b.cost||0));
-      if (affordable[0]) {
-        await this.playFromHand(this.opponent, affordable[0]);
-        if (this.isGameOver()) return;
-      }
-      const attackers = this.opponent.battlefield.cards.filter(c => {
-        if (!(c.type === 'ally' || c.type === 'equipment')) return false;
-        const atk = typeof c.totalAttack === 'function' ? c.totalAttack() : (c.data?.attack || 0);
-        const maxAttacks = c?.keywords?.includes?.('Windfury') ? 2 : 1;
-        const used = c?.data?.attacksUsed || 0;
-        return atk > 0 && !c?.data?.summoningSick && used < maxAttacks;
-      });
-      for (const c of attackers) {
-        if (this.isGameOver()) break;
-        // Enforce Rush restriction on entry: must have a non-hero target available
-        const hasRush = !!c?.keywords?.includes?.('Rush');
-        const justEntered = !!(c?.data?.enteredTurn && c.data.enteredTurn === this.turns.turn);
-        // Stealth is lost when a unit attacks (AI - easy difficulty path)
-        const defenders = [
-          this.player.hero,
-          ...this.player.battlefield.cards.filter(d => d.type !== 'equipment' && d.type !== 'quest')
-        ];
-        const legal = selectTargets(defenders);
-        // If Rush on entry and no non-hero targets, skip attacking with this unit
-        if (hasRush && justEntered) {
-          const nonHero = legal.filter(t => !matchesCardIdentifier(t, this.player.hero));
-          if (nonHero.length === 0) continue;
-        }
-        let block = null;
-        if (legal.length === 1) {
-          const only = legal[0];
-          if (!matchesCardIdentifier(only, this.player.hero)) block = only;
-        } else if (legal.length > 1) {
-          const choices = legal.filter(t => !matchesCardIdentifier(t, this.player.hero));
-          block = this.rng.pick(choices);
-        }
-        const target = block || this.player.hero;
-        await this.throttleAIAction(this.opponent);
-        if (this.isGameOver()) break;
-        const declared = this.combat.declareAttacker(c, target);
-        if (!declared) continue;
-        if (c.data) {
-          c.data.attacked = true;
-          c.data.attacksUsed = (c.data.attacksUsed || 0) + 1;
-        }
-        if (c?.keywords?.includes?.('Stealth')) {
-          c.keywords = c.keywords.filter(k => k !== 'Stealth');
-        }
-        if (block) this.combat.assignBlocker(getCardInstanceId(c), block);
-        this.opponent.log.push(`Attacked ${target.name} with ${c.name}`);
-      }
-      this.combat.setDefenderHero(this.player.hero);
-      const events = this.combat.resolve();
-      for (const ev of events) {
-        const srcOwner = [this.opponent.hero, ...this.opponent.battlefield.cards].includes(ev.source) ? this.opponent : this.player;
-        this.bus.emit('damageDealt', { player: srcOwner, source: ev.source, amount: ev.amount, target: ev.target });
-      }
-      // Allow UI to reflect HP changes before removals
-      if (this._uiRerender) {
-        try { this._uiRerender(); } catch {}
-      }
-      await this.cleanupDeaths(this.player, this.opponent);
-      await this.cleanupDeaths(this.opponent, this.player);
-      this.checkForGameOver();
-      if (this.isGameOver()) return;
+    if (this._pendingTurnIncrement) {
+      this.turns.turn += 1;
+      this._pendingTurnIncrement = false;
     }
 
-    if (this.isGameOver()) return;
-
-    // End AI's turn and start player's turn
-    await this._finalizeOpponentTurn();
+    await this._executeOpponentTurn();
   }
 
   async resumePendingAITurn() {
@@ -1447,16 +1462,23 @@ export default class Game {
     return new MCTS_AI(config);
   }
 
-  async _finalizeOpponentTurn() {
+  async _finalizeOpponentTurn({ preserveTurn = false } = {}) {
     if (this.isGameOver()) return;
     while(this.turns.current !== 'End') {
       this.turns.nextPhase();
     }
-    this.turns.nextPhase(); // End -> Start, turn increments for player
-
-    this.turns.setActivePlayer(this.player);
-    this.turns.startTurn();
-    this.resources.startTurn(this.player);
+    if (preserveTurn) {
+      const prev = this.turns.current;
+      this.turns.bus.emit('phase:end', { phase: prev, turn: this.turns.turn });
+      this.turns.setActivePlayer(this.player);
+      this.turns.startTurn();
+      this.resources.startTurn(this.player);
+    } else {
+      this.turns.nextPhase(); // End -> Start, turn increments for player
+      this.turns.setActivePlayer(this.player);
+      this.turns.startTurn();
+      this.resources.startTurn(this.player);
+    }
   }
 
   async reset(playerDeck = null) {
@@ -1480,6 +1502,7 @@ export default class Game {
     this.resources = new ResourceSystem(this.turns);
     this.player = new Player({ name: 'You' });
     this.opponent = new Player({ name: 'AI' });
+    this._pendingTurnIncrement = false;
     await this.setupMatch(playerDeck);
   }
 

--- a/src/js/utils/turnOrder.js
+++ b/src/js/utils/turnOrder.js
@@ -1,0 +1,19 @@
+// Helpers for choosing turn order using the shared RNG utilities.
+
+/**
+ * Determine which side should take the first turn.
+ * When a seedable RNG is supplied the result is deterministic and
+ * therefore reproducible for seeded matches. Falls back to Math.random
+ * when no RNG is available (e.g., browser quick play).
+ *
+ * @param {object} [rng]
+ * @returns {'player'|'opponent'}
+ */
+export function chooseStartingPlayerKey(rng) {
+  if (rng && typeof rng.randomInt === 'function') {
+    return rng.randomInt(0, 2) === 0 ? 'player' : 'opponent';
+  }
+  return Math.random() < 0.5 ? 'player' : 'opponent';
+}
+
+export default chooseStartingPlayerKey;

--- a/tools/train.mjs
+++ b/tools/train.mjs
@@ -314,7 +314,7 @@ async function evalCandidate(model, { games = 20, maxRounds = 20, opponentConfig
     const seed = g >>> 0;
     game.rng = new RNG(seed);
     await game.setupMatch();
-    game.turns.setActivePlayer(game.player);
+    const startingPlayerKey = game.state?.startingPlayer === 'opponent' ? 'opponent' : 'player';
     setActiveModel(model); // ensure endTurn or direct AI uses this model
 
     // Candidate network always pilots the opponent side; baseline controls the player side
@@ -330,35 +330,78 @@ async function evalCandidate(model, { games = 20, maxRounds = 20, opponentConfig
         fullSim
       });
 
-    // Ensure start is player's turn (Game.setupMatch sets player start)
+    const opponentStarts = startingPlayerKey === 'opponent';
     let rounds = 0;
     let opponentTurns = 0;
     const playerNeedsResume = playerAI instanceof MCTS_AI;
     let resumePlayerTurn = playerNeedsResume;
+    let playerTurns = 0;
+    let pendingTurnIncrement = opponentStarts;
     while (rounds < maxRounds && game.player.hero.data.health > 0 && game.opponent.hero.data.health > 0) {
-      // Player turn (baseline controller)
-      if (playerNeedsResume) {
-        await playerAI.takeTurn(game.player, game.opponent, { resume: resumePlayerTurn });
-        resumePlayerTurn = true;
+      if (game.turns.activePlayer === game.player) {
+        if (playerNeedsResume) {
+          await playerAI.takeTurn(game.player, game.opponent, { resume: resumePlayerTurn });
+          resumePlayerTurn = true;
+        } else {
+          await playerAI.takeTurn(game.player, game.opponent);
+        }
+        playerTurns += 1;
+        if (game.opponent.hero.data.health <= 0 || game.player.hero.data.health <= 0) break;
+
+        if (pendingTurnIncrement) {
+          game.turns.turn += 1;
+          pendingTurnIncrement = false;
+        }
+
+        game.turns.setActivePlayer(game.opponent);
+        game.turns.startTurn();
+        game.resources.startTurn(game.opponent);
+        await opponentAI.takeTurn(game.opponent, game.player);
+        opponentTurns++;
+        if (game.opponent.hero.data.health <= 0 || game.player.hero.data.health <= 0) break;
+
+        while (game.turns.current !== 'End') game.turns.nextPhase();
+        game.turns.nextPhase();
+        game.turns.setActivePlayer(game.player);
+        game.turns.startTurn();
+        game.resources.startTurn(game.player);
+        resumePlayerTurn = playerNeedsResume ? true : resumePlayerTurn;
       } else {
-        await playerAI.takeTurn(game.player, game.opponent);
+        await opponentAI.takeTurn(game.opponent, game.player);
+        opponentTurns++;
+        if (game.opponent.hero.data.health <= 0 || game.player.hero.data.health <= 0) break;
+
+        if (playerTurns === 0) {
+          await game._finalizeOpponentTurn({ preserveTurn: true });
+          pendingTurnIncrement = true;
+        } else {
+          while (game.turns.current !== 'End') game.turns.nextPhase();
+          game.turns.nextPhase();
+          game.turns.setActivePlayer(game.player);
+          game.turns.startTurn();
+          game.resources.startTurn(game.player);
+        }
+
+        if (playerNeedsResume) {
+          await playerAI.takeTurn(game.player, game.opponent, { resume: resumePlayerTurn });
+          resumePlayerTurn = true;
+        } else {
+          await playerAI.takeTurn(game.player, game.opponent);
+        }
+        playerTurns += 1;
+        if (game.opponent.hero.data.health <= 0 || game.player.hero.data.health <= 0) break;
+
+        resumePlayerTurn = playerNeedsResume ? true : resumePlayerTurn;
+
+        if (pendingTurnIncrement) {
+          game.turns.turn += 1;
+          pendingTurnIncrement = false;
+        }
+
+        game.turns.setActivePlayer(game.opponent);
+        game.turns.startTurn();
+        game.resources.startTurn(game.opponent);
       }
-      if (game.opponent.hero.data.health <= 0 || game.player.hero.data.health <= 0) break;
-
-      // Opponent turn
-      game.turns.setActivePlayer(game.opponent);
-      game.turns.startTurn();
-      game.resources.startTurn(game.opponent);
-      await opponentAI.takeTurn(game.opponent, game.player);
-      opponentTurns++;
-
-      // End of opponent turn -> advance to player's next turn
-      while (game.turns.current !== 'End') game.turns.nextPhase();
-      game.turns.nextPhase();
-      game.turns.setActivePlayer(game.player);
-      game.turns.startTurn();
-      game.resources.startTurn(game.player);
-      resumePlayerTurn = playerNeedsResume ? true : resumePlayerTurn;
 
       rounds++;
     }


### PR DESCRIPTION
## Summary
- randomize the starting player while respecting the game's RNG seed
- adjust AI turn execution and CLI tooling to handle either player going first deterministically
- update tests to account for randomized opening hands and ensure player-controlled actions run during the player's turn

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfbbb31d148323be41852f9c8d88bc