### PR TITLE
feat: scale battlecry and hero powers with spell damage

### DIFF
--- a/__tests__/battlecry.spell-damage.test.js
+++ b/__tests__/battlecry.spell-damage.test.js
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+const allyCards = JSON.parse(fs.readFileSync(new URL('../data/cards/ally.json', import.meta.url)));
+
+const sunreaverBowman = allyCards.find(c => c.id === 'ally-sunreaver-bowman');
+
+function setupPlayerForBattlecryTest(game) {
+  game.turns.turn = Math.max(2, game.turns.turn);
+  game.resources.startTurn(game.player);
+  game.turns.setActivePlayer(game.player);
+}
+
+test('Battlecry damage scales with Spell Damage bonuses', async () => {
+  expect(sunreaverBowman).toBeDefined();
+  const g = new Game();
+  setupPlayerForBattlecryTest(g);
+
+  const target = new Card({ name: 'Target Dummy', type: 'ally', data: { attack: 0, health: 4 } });
+  g.opponent.battlefield.add(target);
+
+  const spellBoost = new Card({ name: 'Spell Booster', type: 'ally', data: { attack: 0, health: 1, spellDamage: 1 } });
+  g.player.battlefield.add(spellBoost);
+
+  g.promptTarget = async () => target;
+
+  const battlecry = new Card(sunreaverBowman);
+  g.player.hand.add(battlecry);
+
+  const before = target.data.health;
+  await g.playFromHand(g.player, battlecry.id);
+
+  expect(target.data.health).toBe(before - 2);
+});
+
+test('Battlecry damage deals its base amount without Spell Damage', async () => {
+  expect(sunreaverBowman).toBeDefined();
+  const g = new Game();
+  setupPlayerForBattlecryTest(g);
+
+  const target = new Card({ name: 'Target Dummy', type: 'ally', data: { attack: 0, health: 4 } });
+  g.opponent.battlefield.add(target);
+
+  g.promptTarget = async () => target;
+
+  const battlecry = new Card(sunreaverBowman);
+  g.player.hand.add(battlecry);
+
+  const before = target.data.health;
+  await g.playFromHand(g.player, battlecry.id);
+
+  expect(target.data.health).toBe(before - 1);
+});

--- a/__tests__/jaina-illidan.spell-damage.hero-power.test.js
+++ b/__tests__/jaina-illidan.spell-damage.hero-power.test.js
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+
+const heroCards = JSON.parse(fs.readFileSync(new URL('../data/cards/hero.json', import.meta.url)));
+const jaina = heroCards.find(c => c.id === 'hero-jaina-proudmoore-archmage');
+const illidan = heroCards.find(c => c.id === 'hero-illidan-stormrage-the-betrayer');
+
+function setupHeroPowerTest(game, heroData) {
+  game.player.hero = new Hero(heroData);
+  game.turns.turn = Math.max(2, game.turns.turn);
+  game.resources.startTurn(game.player);
+  game.turns.setActivePlayer(game.player);
+}
+
+test("Jaina's hero power scales with Spell Damage bonuses", async () => {
+  expect(jaina).toBeDefined();
+  const g = new Game();
+  setupHeroPowerTest(g, jaina);
+
+  const target = new Card({ name: 'Training Dummy', type: 'ally', data: { attack: 0, health: 5 } });
+  g.opponent.battlefield.add(target);
+  g.promptTarget = async () => target;
+
+  g.player.hero.data.spellDamage = 1;
+
+  const before = target.data.health;
+  await g.useHeroPower(g.player);
+
+  expect(target.data.health).toBe(before - 2);
+});
+
+test("Jaina's hero power deals base damage without Spell Damage", async () => {
+  expect(jaina).toBeDefined();
+  const g = new Game();
+  setupHeroPowerTest(g, jaina);
+
+  const target = new Card({ name: 'Training Dummy', type: 'ally', data: { attack: 0, health: 5 } });
+  g.opponent.battlefield.add(target);
+  g.promptTarget = async () => target;
+
+  const before = target.data.health;
+  await g.useHeroPower(g.player);
+
+  expect(target.data.health).toBe(before - 1);
+});
+
+test("Illidan's hero power scales with Spell Damage bonuses", async () => {
+  expect(illidan).toBeDefined();
+  const g = new Game();
+  setupHeroPowerTest(g, illidan);
+
+  const enemyMinion = new Card({ name: 'Raid Dummy', type: 'ally', data: { attack: 0, health: 4 } });
+  g.opponent.battlefield.add(enemyMinion);
+
+  g.player.hero.data.spellDamage = 1;
+
+  const heroBefore = g.opponent.hero.data.health;
+  const minionBefore = enemyMinion.data.health;
+
+  await g.useHeroPower(g.player);
+
+  expect(g.opponent.hero.data.health).toBe(heroBefore - 2);
+  expect(enemyMinion.data.health).toBe(minionBefore - 2);
+});

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -245,7 +245,7 @@ export class EffectSystem {
 
   async dealDamage(effect, context) {
     const { target, amount, freeze, beastBonus, comboAmount, usesSpellDamage, friendlyDamageBuff } = effect;
-    const { game, player, card, comboActive } = context;
+    const { game, player, card, comboActive, spellPowerApplies } = context;
     const opponent = player === game.player ? game.opponent : game.player;
       let dmgAmount = amount;
       if (comboActive && typeof comboAmount === 'number') {
@@ -258,7 +258,11 @@ export class EffectSystem {
       // Apply spell damage bonuses when appropriate:
       // - For spells
       // - For explicit non-spell effects that opt-in via `usesSpellDamage`
-      if (card?.type === 'spell' || usesSpellDamage) {
+      const effectTargetsSelfHero = target === 'selfHero';
+      const shouldApplySpellDamage = card?.type === 'spell'
+        || usesSpellDamage
+        || (spellPowerApplies && !effectTargetsSelfHero);
+      if (shouldApplySpellDamage) {
         const bonus = getSpellDamageBonus(player);
         dmgAmount = computeSpellDamage(dmgAmount, bonus);
       }


### PR DESCRIPTION
## Summary
- treat battlecry and hero power effects as spell-damage eligible when they deal direct damage
- ensure damage resolution honours the new flag without boosting self-only hero damage
- add regression tests covering battlecry and hero power spell-damage scaling

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d26d88a6788323ae634d9e32f5fb16