### PR TITLE
fix: prevent battlecry allies from targeting themselves

### DIFF
--- a/__tests__/game.playFromHand.test.js
+++ b/__tests__/game.playFromHand.test.js
@@ -115,3 +115,22 @@ test('canceling targeted ally keeps its original hand position', async () => {
   expect(g.player.hand.cards.indexOf(targetAlly)).toBe(originalIndex);
   expect(g.player.hand.cards.map(c => c.id)).toEqual(initialOrder);
 });
+
+test('battlecry ally cannot select itself as a minion target', async () => {
+  const g = new Game();
+  const battlecryAlly = new Card({
+    type: 'ally',
+    name: 'Careful Slinger',
+    cost: 0,
+    keywords: ['Battlecry'],
+    data: { attack: 1, health: 2 },
+    effects: [{ type: 'damage', target: 'minion', amount: 1 }],
+  });
+  g.player.hand.add(battlecryAlly);
+  g.resources._pool.set(g.player, 10);
+
+  const played = await g.playFromHand(g.player, battlecryAlly.id);
+
+  expect(played).toBe(true);
+  expect(battlecryAlly.data.health).toBe(2);
+});


### PR DESCRIPTION
## Summary
- track the ally being played during battlecry resolution so promptTarget removes it from the candidate list
- store and restore the pending battlecry card while executing effects to avoid self targeting
- add a regression test ensuring a battlecry minion cannot select itself as the target

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d271077ef08323b4cbf79134d6267f