### PR TITLE
Ensure new equipment replaces old gear

### DIFF
--- a/__tests__/equipment.replacement.test.js
+++ b/__tests__/equipment.replacement.test.js
@@ -1,0 +1,54 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+/**
+ * Equipping a new item should destroy the previous equipment for both players.
+ */
+test('equipping a new item destroys previous equipment', async () => {
+  const game = new Game();
+  await game.setupMatch();
+
+  game.player.hand.cards = [];
+  game.player.battlefield.cards = [];
+  game.player.graveyard.cards = [];
+  game.player.log = [];
+  game.resources._pool.set(game.player, 10);
+
+  const first = new Card({
+    id: 'equipment-test-first',
+    name: 'Test Blade',
+    type: 'equipment',
+    cost: 1,
+    attack: 2,
+    durability: 2,
+  });
+  const second = new Card({
+    id: 'equipment-test-second',
+    name: 'Test Shield',
+    type: 'equipment',
+    cost: 1,
+    durability: 1,
+  });
+
+  game.player.hand.add(first);
+  game.player.hand.add(second);
+
+  await game.playFromHand(game.player, first.id);
+  expect(game.player.hero.equipment).toHaveLength(1);
+  expect(game.player.hero.equipment[0]?.id).toBe(first.id);
+
+  await game.playFromHand(game.player, second.id);
+  expect(game.player.hero.equipment).toHaveLength(1);
+  expect(game.player.hero.equipment[0]?.id).toBe(second.id);
+
+  const equipmentOnBoard = game.player.battlefield.cards
+    .filter((card) => card.type === 'equipment')
+    .map((card) => card.id);
+  expect(equipmentOnBoard).toEqual([second.id]);
+
+  const graveyardIds = game.player.graveyard.cards.map((card) => card.id);
+  expect(graveyardIds).toContain(first.id);
+
+  expect(game.player.log.some((entry) => entry.includes('Test Blade was destroyed when Test Shield was equipped.')))
+    .toBe(true);
+});

--- a/src/js/entities/player.js
+++ b/src/js/entities/player.js
@@ -3,6 +3,7 @@ import Zone from './zone.js';
 import Hand from './hand.js';
 import Hero from './hero.js';
 import Equipment from './equipment.js';
+import { replaceEquipment } from '../utils/equipment.js';
 
 export class Player {
   constructor({ id, name = 'Player', hero = null } = {}) {
@@ -29,11 +30,7 @@ export class Player {
 
   equip(item) {
     const eq = item instanceof Equipment ? item : new Equipment(item);
-    // Only one piece of equipment can be active at a time
-    this.hero.equipment = [eq];
-    if (eq.armor) {
-      this.hero.data.armor = (this.hero.data.armor || 0) + eq.armor;
-    }
+    replaceEquipment(this, eq);
     return eq;
   }
 }

--- a/src/js/systems/ai-mcts.js
+++ b/src/js/systems/ai-mcts.js
@@ -8,6 +8,7 @@ import Game from '../game.js';
 import Player from '../entities/player.js';
 import Hero from '../entities/hero.js';
 import { cardsMatch, getCardInstanceId, matchesCardIdentifier } from '../utils/card.js';
+import { replaceEquipment } from '../utils/equipment.js';
 
 // Simple Monte Carlo Tree Search AI
 // - Explores sequences of actions (play card / use hero power / end)
@@ -1600,7 +1601,7 @@ export class MCTS_AI {
       if (played.type === 'ally' || played.type === 'equipment' || played.type === 'quest') {
         p.battlefield.cards.push(played);
         if (played.type === 'equipment') {
-          p.hero.equipment = [played];
+          replaceEquipment(p, played);
         }
         if (played.type === 'ally' && !(played.keywords?.includes('Rush') || played.keywords?.includes('Charge'))) {
           played.data = played.data || {};
@@ -2513,7 +2514,7 @@ export class MCTS_AI {
           }
           if (action.card.type === 'ally' || action.card.type === 'equipment' || action.card.type === 'quest') {
             player.hand.moveTo(player.battlefield, action.card);
-            if (action.card.type === 'equipment') player.hero.equipment = [action.card];
+            if (action.card.type === 'equipment') player.equip(action.card);
             if (action.card.type === 'ally' && !action.card.keywords?.includes('Rush')) {
               action.card.data = action.card.data || {};
               action.card.data.attacked = true;

--- a/src/js/systems/ai.js
+++ b/src/js/systems/ai.js
@@ -3,6 +3,7 @@ import { evaluateGameState } from './ai-heuristics.js';
 import { selectTargets } from './targeting.js';
 import Card from '../entities/card.js';
 import { cardsMatch, getCardInstanceId, matchesCardIdentifier } from '../utils/card.js';
+import { replaceEquipment } from '../utils/equipment.js';
 
 export class BasicAI {
   constructor({ resourceSystem, combatSystem } = {}) {
@@ -257,7 +258,7 @@ export class BasicAI {
       if (played.type === 'ally' || played.type === 'equipment' || played.type === 'quest') {
         p.battlefield.cards.push(played);
         if (played.type === 'equipment') {
-          p.hero.equipment = [played];
+          replaceEquipment(p, played);
         }
         if (played.type === 'ally') {
           played.data = played.data || {};
@@ -364,7 +365,7 @@ export class BasicAI {
       if (best.card.effects) this._applySimpleEffects(best.card.effects, player, opponent, pool);
       if (best.card.type === 'ally' || best.card.type === 'equipment' || best.card.type === 'quest') {
         player.hand.moveTo(player.battlefield, best.card);
-        if (best.card.type === 'equipment') player.hero.equipment = [best.card];
+        if (best.card.type === 'equipment') player.equip(best.card);
         if (best.card.type === 'ally') {
           best.card.data = best.card.data || {};
           best.card.data.enteredTurn = this.resources?.turns?.turn ?? 0;

--- a/src/js/utils/equipment.js
+++ b/src/js/utils/equipment.js
@@ -1,0 +1,93 @@
+import { cardsMatch, matchesCardIdentifier } from './card.js';
+
+function removeFromZone(zone, card) {
+  if (!zone || !card) return null;
+  if (typeof zone.remove === 'function') {
+    const removed = zone.remove(card);
+    if (removed) return removed;
+  }
+  if (Array.isArray(zone.cards)) {
+    const idx = zone.cards.findIndex((c) => cardsMatch(c, card));
+    if (idx !== -1) {
+      return zone.cards.splice(idx, 1)[0];
+    }
+  }
+  return null;
+}
+
+function addToZone(zone, card) {
+  if (!zone || !card) return false;
+  if (typeof zone.add === 'function') {
+    zone.add(card);
+    return true;
+  }
+  if (Array.isArray(zone.cards)) {
+    const exists = zone.cards.some((c) => cardsMatch(c, card));
+    if (!exists) zone.cards.push(card);
+    return true;
+  }
+  return false;
+}
+
+function ensureHeroData(hero) {
+  if (!hero.data) hero.data = {};
+  return hero.data;
+}
+
+export function destroyEquipment(owner, equipment, { replacement = null } = {}) {
+  if (!owner?.hero || !equipment) return null;
+  const { hero } = owner;
+  if (Array.isArray(hero.equipment)) {
+    hero.equipment = hero.equipment.filter((eq) => !cardsMatch(eq, equipment));
+  }
+
+  const removed = removeFromZone(owner.battlefield, equipment);
+  const card = removed || equipment;
+  addToZone(owner.graveyard, card);
+
+  const data = ensureHeroData(hero);
+  const bonus = data.nextSpellDamageBonus;
+  if (bonus?.sourceCardId && matchesCardIdentifier(equipment, bonus.sourceCardId)) {
+    delete data.nextSpellDamageBonus;
+  }
+
+  if (Array.isArray(owner.log) && equipment?.name) {
+    const replacementName = replacement?.name;
+    if (replacementName) {
+      owner.log.push(`${equipment.name} was destroyed when ${replacementName} was equipped.`);
+    } else {
+      owner.log.push(`${equipment.name} was destroyed.`);
+    }
+  }
+
+  return card;
+}
+
+export function replaceEquipment(owner, newEquipment) {
+  if (!owner?.hero) return newEquipment;
+  const { hero } = owner;
+  const current = Array.isArray(hero.equipment) ? hero.equipment : [];
+  const alreadyEquipped = newEquipment ? current.some((eq) => cardsMatch(eq, newEquipment)) : false;
+
+  if (current.length) {
+    for (const eq of current) {
+      if (!newEquipment || !cardsMatch(eq, newEquipment)) {
+        destroyEquipment(owner, eq, { replacement: newEquipment });
+      }
+    }
+  }
+
+  if (newEquipment) {
+    hero.equipment = [newEquipment];
+    if (typeof newEquipment.armor === 'number' && newEquipment.armor !== 0 && !alreadyEquipped) {
+      const data = ensureHeroData(hero);
+      data.armor = (data.armor || 0) + newEquipment.armor;
+    }
+  } else {
+    hero.equipment = [];
+  }
+
+  return newEquipment;
+}
+
+export default replaceEquipment;


### PR DESCRIPTION
## Summary
- ensure Player equips use shared replacement logic that removes prior equipment
- apply the same replacement when AIs simulate or resolve equipment plays
- add a regression test covering equipment replacement behavior

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d279efe8fc832383910dd87fbb9145