### PR TITLE
feat: prioritize friendly targets for positive effects

### DIFF
--- a/__tests__/no-more-targets.targeting.test.js
+++ b/__tests__/no-more-targets.targeting.test.js
@@ -22,8 +22,10 @@ test('multi-target prompts allow early completion after first pick', async () =>
   );
 
   expect(promptSpy).toHaveBeenCalledTimes(2);
-  expect(promptSpy.mock.calls[0][1]).toEqual({ allowNoMore: false });
-  expect(promptSpy.mock.calls[1][1]).toEqual({ allowNoMore: true });
+  expect(promptSpy.mock.calls[0][1]).toMatchObject({ allowNoMore: false, preferredSide: 'enemy' });
+  expect(promptSpy.mock.calls[0][1].actingPlayer).toBe(player);
+  expect(promptSpy.mock.calls[1][1]).toMatchObject({ allowNoMore: true, preferredSide: 'enemy' });
+  expect(promptSpy.mock.calls[1][1].actingPlayer).toBe(player);
   expect(enemy1.data.health).toBe(1);
   expect(enemy2.data.health).toBe(2);
 });

--- a/__tests__/targeting.preferred-side.test.js
+++ b/__tests__/targeting.preferred-side.test.js
@@ -1,0 +1,37 @@
+import Game from '../src/js/game.js';
+
+describe('promptTarget preferred side ordering', () => {
+  test('prioritizes friendly characters when requested', async () => {
+    const g = new Game();
+    await g.setupMatch();
+
+    const friendlyHero = g.player.hero;
+    const enemyHero = g.opponent.hero;
+
+    const choice = await g.promptTarget([enemyHero, friendlyHero], {
+      preferredSide: 'friendly',
+      actingPlayer: g.player,
+    });
+
+    expect(choice === friendlyHero).toBe(true);
+  });
+
+  test('autoplay prefers friendly targets when requested', async () => {
+    const g = new Game();
+    await g.setupMatch();
+
+    g.turns.setActivePlayer(g.player);
+    g.turns.startTurn();
+    g.state.aiThinking = true;
+
+    const friendlyHero = g.player.hero;
+    const enemyHero = g.opponent.hero;
+
+    const choice = await g.promptTarget([enemyHero, friendlyHero], {
+      preferredSide: 'friendly',
+      actingPlayer: g.player,
+    });
+
+    expect(choice === friendlyHero).toBe(true);
+  });
+});

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -126,7 +126,10 @@ export class EffectSystem {
           ]);
           candidates = [...candidates, ...enemy];
         }
-        const chosen = await game.promptTarget(candidates);
+        const chosen = await game.promptTarget(candidates, {
+          preferredSide: isDebuff ? 'enemy' : 'friendly',
+          actingPlayer: player,
+        });
         if (chosen === game.CANCEL) throw game.CANCEL;
         if (chosen) {
           for (const g of grouped) {
@@ -280,7 +283,10 @@ export class EffectSystem {
           ...player.battlefield.cards.filter(c => c.type !== 'quest')
         ].filter((target) => isTargetable(target, { requester: player }));
         const candidates = [...enemy, ...friendly];
-        const chosen = await game.promptTarget(candidates);
+        const chosen = await game.promptTarget(candidates, {
+          preferredSide: 'enemy',
+          actingPlayer: player,
+        });
         if (chosen === game.CANCEL) throw game.CANCEL;
         if (chosen) actualTargets.push(chosen);
         break;
@@ -295,7 +301,10 @@ export class EffectSystem {
           ...opponent.battlefield.cards.filter(c => c.type !== 'quest'),
         ]);
         const candidates = [...friendly, ...enemy];
-        const chosen = await game.promptTarget(candidates);
+        const chosen = await game.promptTarget(candidates, {
+          preferredSide: 'enemy',
+          actingPlayer: player,
+        });
         if (chosen === game.CANCEL) throw game.CANCEL;
         if (chosen) actualTargets.push(chosen);
         break;
@@ -314,7 +323,11 @@ export class EffectSystem {
         for (let i = 0; i < 3; i++) {
           const pick = await game.promptTarget(
             candidates.filter(c => !chosen.has(c)),
-            { allowNoMore: chosen.size > 0 }
+            {
+              allowNoMore: chosen.size > 0,
+              preferredSide: 'enemy',
+              actingPlayer: player,
+            }
           );
           if (pick === game.CANCEL) throw game.CANCEL;
           if (!pick) break;
@@ -353,7 +366,10 @@ export class EffectSystem {
           .filter(c => c.type !== 'quest')
           .filter((target) => isTargetable(target, { requester: player }));
         const candidates = [...enemy, ...friendly];
-        const chosen = await game.promptTarget(candidates);
+        const chosen = await game.promptTarget(candidates, {
+          preferredSide: 'enemy',
+          actingPlayer: player,
+        });
         if (chosen === game.CANCEL) throw game.CANCEL;
         if (chosen) actualTargets.push(chosen);
         break;
@@ -363,7 +379,10 @@ export class EffectSystem {
           opponent.hero,
           ...opponent.battlefield.cards.filter(c => !c.keywords?.includes('Taunt') && c.type !== 'quest'),
         ].filter(isTargetable);
-        const chosen = await game.promptTarget(candidates);
+        const chosen = await game.promptTarget(candidates, {
+          preferredSide: 'enemy',
+          actingPlayer: player,
+        });
         if (chosen === game.CANCEL) throw game.CANCEL;
         if (chosen) actualTargets.push(chosen);
         break;
@@ -708,7 +727,10 @@ export class EffectSystem {
           ...opponent.battlefield.cards.filter(c => c.type !== 'quest')
         ]);
         const candidates = [...friendly, ...enemy];
-        const chosen = await game.promptTarget(candidates);
+        const chosen = await game.promptTarget(candidates, {
+          preferredSide: 'friendly',
+          actingPlayer: player,
+        });
         if (chosen === game.CANCEL) throw game.CANCEL;
         if (chosen) actualTargets.push(chosen);
         break;
@@ -1246,7 +1268,7 @@ export class EffectSystem {
     if (candidates.length === 1) {
       chosen = candidates[0];
     } else {
-      chosen = await game.promptTarget(candidates);
+      chosen = await game.promptTarget(candidates, { actingPlayer: player });
       if (chosen === game.CANCEL) throw game.CANCEL;
       if (!chosen) return;
     }
@@ -1300,7 +1322,11 @@ export class EffectSystem {
     }
 
     // Let the acting side pick a target (AI auto-picks via promptTarget)
-    const chosen = await game.promptTarget(candidates);
+    const preferFriendly = target === 'ally' || target === 'anyAlly';
+    const chosen = await game.promptTarget(candidates, {
+      preferredSide: preferFriendly ? 'friendly' : 'enemy',
+      actingPlayer: player,
+    });
     if (chosen === game.CANCEL) throw game.CANCEL;
     if (!chosen) return;
 
@@ -1330,7 +1356,10 @@ export class EffectSystem {
 
     if (!beasts.length) return;
 
-    const chosen = await game.promptTarget(beasts);
+    const chosen = await game.promptTarget(beasts, {
+      preferredSide: 'friendly',
+      actingPlayer: player,
+    });
     if (chosen === game.CANCEL) throw game.CANCEL;
     if (!chosen) return;
 
@@ -1570,7 +1599,10 @@ export class EffectSystem {
             ]);
             candidates = [...candidates, ...enemy];
           }
-          const chosen = await game.promptTarget(candidates);
+          const chosen = await game.promptTarget(candidates, {
+            preferredSide: isDebuff ? 'enemy' : 'friendly',
+            actingPlayer: player,
+          });
           if (chosen) actualTargets.push(chosen);
         }
         break;
@@ -1750,7 +1782,10 @@ export class EffectSystem {
             ...player.battlefield.cards.filter(c => c.type !== 'quest')
           ].filter((entity) => isTargetable(entity, { requester: player }));
 
-          const chosen = await game.promptTarget(friendly);
+          const chosen = await game.promptTarget(friendly, {
+            preferredSide: 'friendly',
+            actingPlayer: player,
+          });
           if (chosen === game.CANCEL) throw game.CANCEL;
           if (chosen) actualTargets.push(chosen);
         }
@@ -1761,7 +1796,10 @@ export class EffectSystem {
           opponent.hero,
           ...opponent.battlefield.cards.filter(c => c.type !== 'quest')
         ]).filter(isTargetable);
-        const chosen = await game.promptTarget(candidates);
+        const chosen = await game.promptTarget(candidates, {
+          preferredSide: 'enemy',
+          actingPlayer: player,
+        });
         if (chosen === game.CANCEL) throw game.CANCEL;
         if (chosen) actualTargets.push(chosen);
         break;


### PR DESCRIPTION
## Summary
- extend `promptTarget` with preferred side support and actor context to improve ordering for UI and AI
- pass explicit target preferences through heal, buff, and other effect handlers so supportive cards surface friendly options first
- add unit tests covering preferred ordering and update multi-target prompt expectations

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2d82c60188323abe6516268293c9f