### PR TITLE
feat: redesign play layout and sticky hand

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -20,9 +20,9 @@ header {
   flex-wrap: wrap;
   align-items: center;
   gap: 16px;
-  padding: 8px 12px;
-  background: #111923;
-  border-bottom: 1px solid #203040;
+  padding: 16px clamp(16px, 4vw, 32px);
+  background: linear-gradient(180deg, rgba(18, 28, 40, 0.95), rgba(12, 18, 26, 0.95));
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
 }
 
 header strong {
@@ -34,10 +34,12 @@ header strong {
 
 main {
   flex: 1;
-  padding: 12px;
+  padding: clamp(16px, 3vw, 32px);
+  padding-bottom: clamp(48px, 12vh, 128px);
   display: grid;
   grid-template-columns: 1fr;
-  gap: 12px;
+  gap: clamp(16px, 3vw, 32px);
+  align-content: start;
 }
 
 /* Hide sidebar by default; shown when deck builder is active */
@@ -47,53 +49,257 @@ main {
 
 /* Board layout inside #root */
 #root .board {
+  position: relative;
   display: grid;
-  grid-template-columns: 240px minmax(470px, 1fr) 240px;
-  grid-auto-rows: min-content;
-  gap: 12px 16px;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr) minmax(260px, 320px);
+  grid-template-rows:
+    auto
+    auto
+    minmax(160px, auto)
+    minmax(180px, auto)
+    auto
+    minmax(220px, auto);
   grid-template-areas:
-    'ai-mana  ai-hand  ai-log'
-    'ai-hero  ai-field ai-log'
-    'p-hero   p-field  p-log'
-    'p-mana   p-hand   p-log';
+    'ai-info ai-hand ai-log'
+    'ai-info ai-hero ai-log'
+    'ai-info ai-field ai-log'
+    'p-info  p-field p-log'
+    'p-info  p-hero  p-log'
+    'p-hand  p-hand  p-hand';
+  gap: clamp(16px, 3vw, 32px);
+  align-items: start;
+  padding-bottom: clamp(32px, 8vh, 128px);
+}
+
+@media (max-width: 1100px) {
+  #root .board {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: none;
+    grid-template-areas:
+      'ai-hand'
+      'ai-hero'
+      'ai-info'
+      'ai-field'
+      'ai-log'
+      'p-field'
+      'p-hero'
+      'p-info'
+      'p-log'
+      'p-hand';
+  }
+
+  .ai-log,
+  .p-log {
+    min-height: 200px;
+  }
 }
 
 /* Assign grid areas */
 .ai-hero { grid-area: ai-hero; }
-.ai-mana { grid-area: ai-mana; }
+.ai-mana { grid-area: ai-info; }
 .ai-hand { grid-area: ai-hand; }
 .ai-field { grid-area: ai-field; }
 .ai-log { grid-area: ai-log; }
 .p-hero { grid-area: p-hero; }
-.p-mana { grid-area: p-mana; }
+.p-mana { grid-area: p-info; }
 .p-hand { grid-area: p-hand; }
 .p-field { grid-area: p-field; }
 .p-log { grid-area: p-log; }
 
-.board .zone,
-.board .slot {
-  background: #10171f;
-  padding: 8px;
-  border: 1px solid #203040;
-  border-radius: 4px;
+.board .zone {
+  background: rgba(16, 23, 31, 0.78);
+  padding: 16px;
+  border: none;
+  border-radius: 16px;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.35);
 }
 
-.board h3 { margin: 4px 0 8px; }
+.board .slot {
+  border: none;
+  background: none;
+  padding: 0;
+}
+
+.board h3 {
+  margin: 0 0 12px;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8fa2b5;
+}
+
+.slot.ai-mana,
+.slot.p-mana {
+  display: flex;
+  flex-direction: column;
+  align-self: start;
+  gap: 6px;
+  color: #c5d6e6;
+}
+
+.slot.ai-mana h3,
+.slot.p-mana h3 {
+  margin: 0;
+}
+
+.slot.ai-mana .mana,
+.slot.p-mana .mana {
+  font-size: clamp(22px, 3vw, 28px);
+  font-weight: 600;
+  color: #f5fafc;
+}
+
+.slot.ai-hero,
+.slot.p-hero {
+  background: rgba(16, 29, 44, 0.85);
+  padding: 16px;
+  border-radius: 20px;
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}
+
+.slot.ai-hero h3,
+.slot.p-hero h3 {
+  margin: 0;
+}
+
+.slot.ai-hero .card-tooltip,
+.slot.p-hero .card-tooltip {
+  margin: 0 auto;
+}
+
+.ai-field,
+.p-field {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.ai-field .cards,
+.p-field .cards {
+  gap: clamp(12px, 2vw, 20px);
+  min-height: 140px;
+}
+
+.ai-hand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 12px;
+}
+
+.ai-hand .count {
+  font-size: 14px;
+  letter-spacing: 0.06em;
+  color: #cad6e4;
+}
+
+.ai-hand[data-debug-view='1'] .cards {
+  justify-content: center;
+}
+
+.log-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+}
+
+.log-pane ul {
+  flex: 1;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  max-height: none;
+  min-height: 220px;
+}
+
+.ai-log {
+  background: rgba(24, 58, 82, 0.72);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
+}
+
+.p-log {
+  background: rgba(56, 32, 72, 0.72);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+}
+
+.p-hand {
+  position: sticky;
+  bottom: 0;
+  align-self: stretch;
+  border-radius: 28px 28px 0 0;
+  background: linear-gradient(180deg, rgba(11, 15, 20, 0) 0%, rgba(11, 15, 20, 0.85) 45%, rgba(11, 15, 20, 0.98) 100%);
+  box-shadow: 0 -28px 80px rgba(0, 0, 0, 0.7);
+  padding: 16px clamp(24px, 6vw, 80px) 40px;
+  overflow: visible;
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  --hand-overlap: 100px;
+  z-index: 250;
+}
+
+.p-hand h3 {
+  margin: 0 0 18px;
+  text-align: center;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 14px;
+  color: #8fa2b5;
+}
+
+.p-hand .cards {
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 0;
+  padding-bottom: 16px;
+  min-height: clamp(200px, 32vh, 300px);
+  overflow: visible;
+}
+
+.p-hand .card-tooltip {
+  flex: 0 0 auto;
+  margin-left: calc(-1 * var(--hand-overlap, 100px));
+  transform-origin: bottom center;
+  transform: translateY(calc(var(--fan-translate, 0) * 1%)) rotate(var(--fan-rotate, 0deg)) scale(0.88);
+  transition: transform 0.25s ease, filter 0.25s ease, z-index 0.25s ease;
+  filter: drop-shadow(0 18px 30px rgba(0, 0, 0, 0.5));
+  z-index: var(--fan-z, 1);
+}
+
+.p-hand .card-tooltip:first-child {
+  margin-left: 0;
+}
+
+.p-hand .card-tooltip:hover,
+.p-hand .card-tooltip:focus-within {
+  transform: translateY(-70%) scale(1.05);
+  z-index: 999;
+  filter: drop-shadow(0 36px 60px rgba(0, 0, 0, 0.75));
+}
 
 /* Card containers */
 .cards {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 12px;
+  justify-content: center;
 }
 
 .cards .card-tooltip { cursor: pointer; }
 
 footer {
-  padding: 8px 12px;
+  padding: 12px clamp(16px, 4vw, 32px);
   font-size: 12px;
   opacity: 0.7;
-  border-top: 1px solid #203040;
 }
 
 .row {
@@ -103,24 +309,11 @@ footer {
 }
 
 .zone {
-  background: #10171f;
-  padding: 8px;
-  border: 1px solid #203040;
-  border-radius: 4px;
-}
-
-.log-pane {
-  display: flex;
-  flex-direction: column;
-}
-
-.log-pane ul {
-  flex: 1;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  overflow-y: auto;
-  max-height: 450px;
+  background: rgba(16, 23, 31, 0.78);
+  padding: 16px;
+  border: none;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.3);
 }
 
 ul.zone-list {


### PR DESCRIPTION
## Summary
- rearranged the play board grid so the enemy hero, player hero, and logs match the requested layout while dropping decorative borders
- styled the player interface with a sticky hand tray, responsive spacing, and toned header/footer treatments
- fanned player hand cards with scripted transforms so hover raises the card fully above the tray

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d41df22ad88323a070ad5b018c28c1