### PR TITLE
Remove hero and battlefield UI labels

### DIFF
--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -766,20 +766,18 @@ export function renderPlay(container, game, {
     const aiHero = el(
       'div',
       { class: 'slot ai-hero' },
-      el('h3', {}, 'AI hero'),
       el('div', { class: 'hero-mana' }, `${game.resources.pool(e)}/${game.resources.available(e)} Mana`),
       buildCardEl(e.hero),
       buildAiHandIndicator(e.hand)
     );
     const aiLog = logPane('Enemy Log', e.log); aiLog.classList.add('ai-log');
     const aiHand = buildAiHandZone(e.hand, { owner: e, debugOn: debugEnabled });
-    const aiField = zoneCards('Enemy Battlefield', e.battlefield.cards, { owner: e }); aiField.classList.add('ai-field');
+    const aiField = zoneCards(null, e.battlefield.cards, { owner: e }); aiField.classList.add('ai-field');
 
     // Player side
     const pHero = el(
       'div',
       { class: 'slot p-hero' },
-      el('h3', {}, 'Player hero'),
       el('div', { class: 'hero-mana' }, `${game.resources.pool(p)}/${game.resources.available(p)} Mana`),
       buildCardEl(p.hero)
     );
@@ -789,7 +787,7 @@ export function renderPlay(container, game, {
       heroEl.dataset.clickAttached = '1';
     }
     const pLog = logPane('Player Log', p.log); pLog.classList.add('p-log');
-    const pField = zoneCards('Player Battlefield', p.battlefield.cards, { owner: p, clickCard: async (c)=>{ await game.attack(game.player, c); onUpdate?.(); } }); pField.classList.add('p-field');
+    const pField = zoneCards(null, p.battlefield.cards, { owner: p, clickCard: async (c)=>{ await game.attack(game.player, c); onUpdate?.(); } }); pField.classList.add('p-field');
     const pHand = zoneCards(null, p.hand.cards, { owner: p, clickCard: async (c)=>{ if (!await game.playFromHand(game.player, c)) { /* ignore */ } onUpdate?.(); } }); pHand.classList.add('p-hand');
     board.append(aiHero);
     if (aiHand) board.append(aiHand);


### PR DESCRIPTION
## Summary
- remove hero headings from AI and player slots in the play view
- hide battlefield zone titles for both enemy and player sections

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4424f9d3083239688db6085b48d28