### PR TITLE
feat: improve touch interactions in hand

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -254,7 +254,8 @@ main {
 }
 
 .p-hand .card-tooltip:hover,
-.p-hand .card-tooltip:focus-within {
+.p-hand .card-tooltip:focus-within,
+.p-hand .card-tooltip[data-touch-preview='1'] {
   transform: translateY(-60%) scale(1.05);
   z-index: 999;
   filter: drop-shadow(0 36px 60px rgba(0, 0, 0, 0.75));
@@ -376,7 +377,8 @@ main {
   }
 
   .p-hand .card-tooltip:hover,
-  .p-hand .card-tooltip:focus-within {
+  .p-hand .card-tooltip:focus-within,
+  .p-hand .card-tooltip[data-touch-preview='1'] {
     transform: translateY(-30%) scale(1.25);
   }
 }


### PR DESCRIPTION
## Summary
- add touch-aware interaction handling for player hand cards that previews on tap and plays on double-tap
- keep preview state in sync with DOM updates and removals
- style touch previews to mirror the existing hover treatment

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d449d837388323b06ecb410012688d