### PR TITLE
fix: respect rush restrictions during autoplay

### DIFF
--- a/__tests__/ai.summoning-sickness.test.js
+++ b/__tests__/ai.summoning-sickness.test.js
@@ -40,3 +40,25 @@ test('AI does not attack with summoned ally', () => {
   expect(g.opponent.hero.data.health).toBe(10);
 });
 
+test('AI rush ally cannot attack opponent hero on entry', () => {
+  const g = new Game();
+  const ai = new BasicAI({ resourceSystem: g.resources, combatSystem: g.combat });
+  g.player.hero = new Hero({ name: 'AI', data: { health: 10 } });
+  g.opponent.hero = new Hero({ name: 'Opponent', data: { health: 10 } });
+  const rush = new Card({
+    type: 'ally',
+    name: 'Sprinter',
+    cost: 0,
+    data: { attack: 2, health: 1 },
+    keywords: ['Rush']
+  });
+  g.player.hand.add(rush);
+  g.turns.setActivePlayer(g.player);
+  g.turns.startTurn();
+  ai.takeTurn(g.player, g.opponent);
+  const played = g.player.battlefield.cards.find(c => c.name === 'Sprinter');
+  expect(played).toBeDefined();
+  expect(played.data.enteredTurn).toBe(g.turns.turn);
+  expect(g.opponent.hero.data.health).toBe(10);
+});
+

--- a/src/js/systems/ai.js
+++ b/src/js/systems/ai.js
@@ -77,6 +77,9 @@ export class BasicAI {
               data: { attack: unit.attack, health: unit.health },
               keywords: unit.keywords
             });
+            const turnValue = this.resources?.turns?.turn ?? 0;
+            summoned.data = summoned.data || {};
+            summoned.data.enteredTurn = turnValue;
             if (!summoned.keywords?.includes('Rush')) {
               summoned.data.attacked = true;
             }


### PR DESCRIPTION
## Summary
- ensure BasicAI marks summoned allies with the current turn so Rush units still count as freshly summoned
- add a regression test verifying the AI will not send a just-summoned Rush ally at the opposing hero

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d464115d648323ac731dbbdc24633f