### PR TITLE
fix: throttle autoplay actions

### DIFF
--- a/__tests__/autoplay.prompts.test.js
+++ b/__tests__/autoplay.prompts.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import Game from '../src/js/game.js';
 
 describe('autoplay prompt handling', () => {
@@ -29,5 +30,29 @@ describe('autoplay prompt handling', () => {
     const selection = await g.promptOption(['One', 'Two', 'Three']);
 
     expect(selection).toBe(2);
+  });
+
+  test('player actions throttle while autoplaying', async () => {
+    jest.useFakeTimers();
+    try {
+      const g = new Game();
+      await g.setupMatch();
+
+      g._shouldThrottleAI = true;
+      g.state.aiThinking = true;
+
+      const pending = g.throttleAIAction(g.player);
+      let resolved = false;
+      pending.then(() => { resolved = true; });
+
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      jest.advanceTimersByTime(1000);
+      await pending;
+      expect(resolved).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -247,7 +247,8 @@ export default class Game {
 
   async throttleAIAction(player) {
     if (!this._shouldThrottleAI) return;
-    if (!this._isAIControlled(player)) return;
+    const autoplayingPlayer = this.state?.aiThinking && player === this.player;
+    if (!this._isAIControlled(player) && !autoplayingPlayer) return;
     const delay = this._aiActionDelayMs;
     if (!(delay > 0)) return;
     await new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- ensure AI action throttling also applies when the player is autoplaying
- add a regression test that verifies player actions wait for the autoplay delay

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d46650642c832384dc1603aa911b09