### PR TITLE
feat: summon recruits when Uther spends mana

### DIFF
--- a/__tests__/uther.passive.test.js
+++ b/__tests__/uther.passive.test.js
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+
+const heroCards = JSON.parse(fs.readFileSync(new URL('../data/cards/hero.json', import.meta.url)));
+const allyCards = JSON.parse(fs.readFileSync(new URL('../data/cards/ally.json', import.meta.url)));
+
+const utherData = heroCards.find((c) => c.id === 'hero-uther-the-lightbringer');
+const fallbackHero = heroCards.find((c) => c.id !== 'hero-uther-the-lightbringer');
+
+function setupGameWithUther() {
+  const game = new Game();
+  game.player.hero = new Hero(utherData);
+  game.player.hero.owner = game.player;
+  if (fallbackHero) {
+    game.opponent.hero = new Hero(fallbackHero);
+    game.opponent.hero.owner = game.opponent;
+  }
+  game.allCards = [utherData, ...allyCards];
+  game._cardIndex = new Map(game.allCards.map((card) => [card.id, card]));
+  return game;
+}
+
+async function activatePassive(game) {
+  if (!game.player?.hero?.passive?.length) return;
+  await game.effects.execute(game.player.hero.passive, {
+    game,
+    player: game.player,
+    card: game.player.hero,
+  });
+}
+
+const countRecruits = (game) =>
+  game.player.battlefield.cards.filter((c) => c.id === 'ally-silver-hand-recruit').length;
+
+test('Uther summons a Silver Hand Recruit every 5 mana spent', async () => {
+  expect(utherData).toBeDefined();
+  const game = setupGameWithUther();
+  await activatePassive(game);
+
+  expect(countRecruits(game)).toBe(0);
+
+  game.bus.emit('resources:spent', { player: game.player, amount: 3 });
+  game.bus.emit('cardPlayed', { player: game.player, card: { id: 'test-spell', type: 'spell' } });
+  expect(countRecruits(game)).toBe(0);
+
+  game.bus.emit('resources:spent', { player: game.player, amount: 2 });
+  game.bus.emit('heroPowerUsed', { player: game.player, hero: game.player.hero, cost: 2 });
+  let recruits = game.player.battlefield.cards.filter((c) => c.id === 'ally-silver-hand-recruit');
+  expect(recruits).toHaveLength(1);
+  expect(recruits[0]?.data?.attack ?? recruits[0]?.attack).toBe(1);
+  expect(recruits[0]?.data?.health ?? recruits[0]?.health).toBe(1);
+
+  game.bus.emit('resources:spent', { player: game.player, amount: 4 });
+  game.bus.emit('resources:refunded', { player: game.player, amount: 4 });
+  game.bus.emit('cardPlayed', { player: game.player, card: { id: 'cancelled', type: 'spell' } });
+  expect(countRecruits(game)).toBe(1);
+
+  game.bus.emit('resources:spent', { player: game.player, amount: 5 });
+  game.bus.emit('cardPlayed', { player: game.player, card: { id: 'big-spell', type: 'spell' } });
+  expect(countRecruits(game)).toBe(2);
+});

--- a/data/cards/ally.json
+++ b/data/cards/ally.json
@@ -2240,5 +2240,19 @@
     },
     "text": "Taunt.",
     "prompt": "A massive guardian beast stands firm beneath Ashenvale boughs, bark-like fur bristling."
+  },
+  {
+    "id": "ally-silver-hand-recruit",
+    "name": "Silver Hand Recruit",
+    "type": "ally",
+    "cost": 1,
+    "effects": [],
+    "keywords": [],
+    "data": {
+      "attack": 1,
+      "health": 1
+    },
+    "text": "",
+    "prompt": "Art to be provided by user."
   }
 ]

--- a/data/cards/hero.json
+++ b/data/cards/hero.json
@@ -155,6 +155,13 @@
         "duration": "thisTurn"
       }
     ],
+    "passive": [
+      {
+        "type": "summonOnManaSpent",
+        "cardId": "ally-silver-hand-recruit",
+        "threshold": 5
+      }
+    ],
     "keywords": [
       "Summon a 1/1 Silver Hand Recruit every 5 mana spent this game."
     ],

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -99,9 +99,9 @@ export default class Game {
 
     // Systems
     this.turns = new TurnSystem();
-    this.resources = new ResourceSystem(this.turns);
     // Create the event bus before systems that depend on it
     this.bus = new EventBus();
+    this.resources = new ResourceSystem(this.turns, this.bus);
     this.combat = new CombatSystem(this.bus);
     this.effects = new EffectSystem(this);
     const rawSeed = opts?.seed;
@@ -754,6 +754,7 @@ export default class Game {
       throw err;
     }
     hero.powerUsed = true;
+    try { this.bus.emit('heroPowerUsed', { player, hero, cost }); } catch {}
     if (Array.isArray(player?.log)) {
       if ((!Array.isArray(logTargets) || logTargets.length === 0) && loggedTargets.size > 0) {
         logTargets = Array.from(loggedTargets);
@@ -1786,7 +1787,7 @@ export default class Game {
       this.combat.clear();
       this.combat.setDefenderHero(null);
     }
-    this.resources = new ResourceSystem(this.turns);
+    this.resources = new ResourceSystem(this.turns, this.bus);
     this.player = new Player({ name: 'You' });
     this.opponent = new Player({ name: 'AI' });
     this._pendingTurnIncrement = false;


### PR DESCRIPTION
## Summary
- add Silver Hand Recruit ally card data and hook Uther's passive to summon it after every 5 mana spent
- emit mana spend/refund events and implement the summonOnManaSpent effect handler
- add coverage for the new passive behaviour with a dedicated test

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4e0b0e6d48323b4133aa892923f88