### PR TITLE
feat: enforce ally battlefield limit

### DIFF
--- a/__tests__/ally.battlefield-limit.test.js
+++ b/__tests__/ally.battlefield-limit.test.js
@@ -1,0 +1,83 @@
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+import Card from '../src/js/entities/card.js';
+
+function createAlly(name, { attack = 1, health = 1, keywords = [], deathrattle = null } = {}) {
+  const card = new Card({
+    type: 'ally',
+    name,
+    cost: 0,
+    data: { attack, health },
+    keywords,
+  });
+  if (deathrattle) {
+    card.deathrattle = deathrattle;
+  }
+  return card;
+}
+
+describe('battlefield ally limit', () => {
+  test('playing a sixth ally destroys the oldest and triggers its deathrattle', async () => {
+    const game = new Game();
+    game.player.hero = new Hero({ name: 'Player Hero', data: { health: 30 } });
+    game.opponent.hero = new Hero({ name: 'Opponent Hero', data: { health: 30 } });
+
+    const defeated = [];
+    game.bus.on('allyDefeated', (payload) => defeated.push(payload));
+
+    const oldest = createAlly('Veteran', {
+      keywords: ['Deathrattle'],
+      deathrattle: [{ type: 'damage', target: 'allEnemies', amount: 2 }],
+    });
+    game.player.battlefield.add(oldest);
+    for (let i = 0; i < 4; i++) {
+      game.player.battlefield.add(createAlly(`Ally ${i + 2}`));
+    }
+
+    const newAlly = createAlly('Reinforcement');
+    game.player.hand.add(newAlly);
+
+    await game.playFromHand(game.player, newAlly.id);
+
+    expect(game.player.battlefield.cards).toHaveLength(5);
+    expect(game.player.battlefield.cards).toContain(newAlly);
+    expect(game.player.battlefield.cards).not.toContain(oldest);
+    expect(game.player.graveyard.cards).toContain(oldest);
+    expect(game.opponent.hero.data.health).toBe(28);
+    expect(defeated.some(({ card, player }) => card === oldest && player === game.player)).toBe(true);
+  });
+
+  test('summoning beyond the limit removes the oldest allies first', async () => {
+    const game = new Game();
+    game.player.hero = new Hero({ name: 'Player Hero', data: { health: 30 } });
+    game.opponent.hero = new Hero({ name: 'Opponent Hero', data: { health: 30 } });
+
+    const existing = [];
+    for (let i = 0; i < 5; i++) {
+      const ally = createAlly(`Board Ally ${i + 1}`);
+      game.player.battlefield.add(ally);
+      existing.push(ally);
+    }
+
+    const spell = new Card({
+      type: 'spell',
+      name: 'Reinforcements',
+      cost: 0,
+      effects: [{
+        type: 'summon',
+        unit: { name: 'Token', attack: 1, health: 1 },
+        count: 2,
+      }],
+    });
+    game.player.hand.add(spell);
+
+    await game.playFromHand(game.player, spell.id);
+
+    const tokenCount = game.player.battlefield.cards.filter((c) => c.name === 'Token').length;
+    expect(tokenCount).toBe(2);
+    expect(game.player.battlefield.cards).toHaveLength(5);
+    expect(game.player.battlefield.cards).not.toContain(existing[0]);
+    expect(game.player.battlefield.cards).not.toContain(existing[1]);
+    expect(game.player.graveyard.cards).toEqual(expect.arrayContaining([existing[0], existing[1]]));
+  });
+});

--- a/src/js/systems/ai.js
+++ b/src/js/systems/ai.js
@@ -4,6 +4,7 @@ import { selectTargets } from './targeting.js';
 import Card from '../entities/card.js';
 import { cardsMatch, getCardInstanceId, matchesCardIdentifier } from '../utils/card.js';
 import { replaceEquipment } from '../utils/equipment.js';
+import { removeOverflowAllies } from '../utils/allies.js';
 
 export class BasicAI {
   constructor({ resourceSystem, combatSystem } = {}) {
@@ -84,6 +85,7 @@ export class BasicAI {
               summoned.data.attacked = true;
             }
             player.battlefield.cards.push(summoned);
+            removeOverflowAllies(player);
           }
           break;
         }
@@ -264,6 +266,7 @@ export class BasicAI {
           replaceEquipment(p, played);
         }
         if (played.type === 'ally') {
+          removeOverflowAllies(p);
           played.data = played.data || {};
           played.data.enteredTurn = this.resources?.turns?.turn ?? 0;
           if (!played.keywords?.includes('Rush')) {

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -532,6 +532,12 @@ export class EffectSystem {
         newUnit.data.summoningSick = true;
       }
       player.battlefield.add(newUnit);
+      if (game?.enforceBattlefieldAllyLimit) {
+        const allyCount = player.battlefield.cards.filter(c => c?.type === 'ally').length;
+        if (allyCount > 5) {
+          await game.enforceBattlefieldAllyLimit(player, { source: newUnit });
+        }
+      }
       console.log(`Summoned ${newUnit.name} to battlefield.`);
       game?.bus.emit('unitSummoned', { player, card: newUnit });
 

--- a/src/js/utils/allies.js
+++ b/src/js/utils/allies.js
@@ -1,0 +1,36 @@
+export function removeOverflowAllies(player, { limit = 5 } = {}) {
+  if (!player || !player.battlefield || !Array.isArray(player.battlefield.cards)) {
+    return [];
+  }
+
+  const allies = player.battlefield.cards.filter((card) => card?.type === 'ally');
+  const overflow = allies.length - limit;
+  if (overflow <= 0) return [];
+
+  const toRemove = allies.slice(0, overflow);
+  const removed = [];
+
+  for (const card of toRemove) {
+    let moved = null;
+    if (typeof player.battlefield.moveTo === 'function' && player.graveyard) {
+      moved = player.battlefield.moveTo(player.graveyard, card);
+    }
+
+    if (!moved) {
+      const zoneCards = player.battlefield.cards;
+      const idx = zoneCards.indexOf(card);
+      if (idx !== -1) zoneCards.splice(idx, 1);
+      if (player.graveyard) {
+        if (typeof player.graveyard.add === 'function') player.graveyard.add(card);
+        else if (Array.isArray(player.graveyard.cards)) player.graveyard.cards.push(card);
+      }
+      moved = card;
+    }
+
+    if (moved) removed.push(moved);
+  }
+
+  return removed;
+}
+
+export default removeOverflowAllies;


### PR DESCRIPTION
## Summary
- enforce a five-ally battlefield limit when allies enter play and fire deathrattles/log messages for removed units
- share a helper to trim overflow allies and integrate it with summon effects plus AI simulations
- add regression coverage validating ally destruction and summon overflow behavior

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f285d5608323963518622313abfd