### PR TITLE
fix: allow Uther passive to trigger repeatedly

### DIFF
--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -922,17 +922,16 @@ export class EffectSystem {
 
     const commitPending = async (fallbackAmount = null) => {
       const queue = heroData[queueKey];
-      let amount = null;
+      let amount = 0;
       while (queue.length > 0) {
         const candidate = queue.shift();
         const parsed = Number(candidate);
         if (Number.isFinite(parsed) && parsed > 0) {
-          amount = parsed;
-          break;
+          amount += parsed;
         }
       }
 
-      if ((!Number.isFinite(amount) || amount <= 0) && Number.isFinite(fallbackAmount) && fallbackAmount > 0) {
+      if (amount <= 0 && Number.isFinite(fallbackAmount) && fallbackAmount > 0) {
         amount = fallbackAmount;
       }
 


### PR DESCRIPTION
## Summary
- ensure the summonOnManaSpent effect totals all queued resource spend events before evaluating triggers

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d51491674c8323b68ff9a511300786