### PR TITLE
fix: prevent illidan hero power from scaling with spell damage

### DIFF
--- a/__tests__/jaina-illidan.spell-damage.hero-power.test.js
+++ b/__tests__/jaina-illidan.spell-damage.hero-power.test.js
@@ -46,7 +46,7 @@ test("Jaina's hero power deals base damage without Spell Damage", async () => {
   expect(target.data.health).toBe(before - 1);
 });
 
-test("Illidan's hero power scales with Spell Damage bonuses", async () => {
+test("Illidan's hero power ignores Spell Damage bonuses", async () => {
   expect(illidan).toBeDefined();
   const g = new Game();
   setupHeroPowerTest(g, illidan);
@@ -61,6 +61,6 @@ test("Illidan's hero power scales with Spell Damage bonuses", async () => {
 
   await g.useHeroPower(g.player);
 
-  expect(g.opponent.hero.data.health).toBe(heroBefore - 2);
-  expect(enemyMinion.data.health).toBe(minionBefore - 2);
+  expect(g.opponent.hero.data.health).toBe(heroBefore - 1);
+  expect(enemyMinion.data.health).toBe(minionBefore - 1);
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -51,6 +51,15 @@ function buildDeckFromTemplate(template, cardById) {
   return { hero: heroData, cards, name: template.name || null };
 }
 
+function hasKeyword(entity, keyword) {
+  if (!entity || !keyword) return false;
+  const normalized = keyword.trim().toLowerCase();
+  if (!normalized) return false;
+  const list = entity.keywords;
+  if (!Array.isArray(list) || list.length === 0) return false;
+  return list.some((kw) => typeof kw === 'string' && kw.trim().toLowerCase() === normalized);
+}
+
 function effectListDealsDamageToOthers(effects) {
   if (!Array.isArray(effects)) return false;
   for (const effect of effects) {
@@ -745,7 +754,8 @@ export default class Game {
     await this.throttleAIAction(player);
     const finishTargetCapture = this._pushActionTargetScope();
     const loggedTargets = new Set();
-    const heroPowerUsesSpellDamage = effectListDealsDamageToOthers(hero.active);
+    const heroPowerUsesSpellDamage = effectListDealsDamageToOthers(hero.active)
+      && !hasKeyword(hero, 'Unaffected by spellpower');
     const context = {
       game: this,
       player,


### PR DESCRIPTION
## Summary
- add a helper for keyword lookups so hero powers can respect immunities
- prevent Illidan's hero power from consuming spell damage bonuses
- update the Illidan hero power test to assert the new behavior

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d525662f088323921181e6a18d6795