### PR TITLE
feat: add Arthas armor passive

### DIFF
--- a/__tests__/arthas.passive.test.js
+++ b/__tests__/arthas.passive.test.js
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Hero from '../src/js/entities/hero.js';
+
+const heroCards = JSON.parse(fs.readFileSync(new URL('../data/cards/hero.json', import.meta.url)));
+
+const arthasData = heroCards.find((c) => c.id === 'hero-arthas-menethil-deathlord');
+const fallbackHero = heroCards.find((c) => c.id !== 'hero-arthas-menethil-deathlord');
+
+function setupGameWithArthas() {
+  const game = new Game();
+  game.player.hero = new Hero(arthasData);
+  game.player.hero.owner = game.player;
+  if (fallbackHero) {
+    game.opponent.hero = new Hero(fallbackHero);
+    game.opponent.hero.owner = game.opponent;
+  }
+  return game;
+}
+
+async function activatePassive(game) {
+  if (!game.player?.hero?.passive?.length) return;
+  await game.effects.execute(game.player.hero.passive, {
+    game,
+    player: game.player,
+    card: game.player.hero,
+  });
+}
+
+test('Arthas gains 1 Armor at the end of each of your turns', async () => {
+  expect(arthasData).toBeDefined();
+
+  const game = setupGameWithArthas();
+  await activatePassive(game);
+
+  const { hero } = game.player;
+  expect(hero.data.armor).toBe(0);
+
+  game.turns.bus.emit('turn:start', { player: game.player });
+  expect(hero.data.armor).toBe(0);
+
+  game.turns.bus.emit('turn:start', { player: game.opponent });
+  expect(hero.data.armor).toBe(1);
+
+  game.turns.bus.emit('turn:start', { player: game.player });
+  expect(hero.data.armor).toBe(1);
+
+  game.turns.bus.emit('turn:start', { player: game.opponent });
+  expect(hero.data.armor).toBe(2);
+});

--- a/data/cards/hero.json
+++ b/data/cards/hero.json
@@ -371,6 +371,12 @@
     "id": "hero-arthas-menethil-deathlord",
     "name": "Arthas Menethil, Deathlord",
     "type": "hero",
+    "passive": [
+      {
+        "type": "gainArmorAtEndOfTurn",
+        "amount": 1
+      }
+    ],
     "effects": [
       {
         "type": "damage",


### PR DESCRIPTION
## Summary
- implement Arthas' passive effect that grants 1 Armor at the end of the controller's turns
- wire the new effect into the effect system and cover it with a dedicated test

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5275412948323b5ef5e14ab4f4b53