### PR TITLE
feat: prefix combat log entries with turn number

### DIFF
--- a/__tests__/combat-log.targets.test.js
+++ b/__tests__/combat-log.targets.test.js
@@ -81,7 +81,7 @@ test('logs targeted actions when playing a spell', async () => {
   expect(ok).toBe(true);
 
   const lastLog = g.player.log[g.player.log.length - 1];
-  expect(lastLog).toBe(`Played ${spell.name} targeting ${target.name}`);
+  expect(lastLog).toBe(`5: Played ${spell.name} targeting ${target.name}`);
 });
 
 test('auto-selected destroy effects still log their target', async () => {
@@ -118,7 +118,7 @@ test('auto-selected destroy effects still log their target', async () => {
   formatSpy.mockRestore();
 
   const lastLog = g.player.log[g.player.log.length - 1];
-  expect(lastLog).toBe(`Played ${spell.name} targeting ${enemy.name}`);
+  expect(lastLog).toBe(`5: Played ${spell.name} targeting ${enemy.name}`);
 });
 
 test('AI auto-selected destroy effects log their target', async () => {
@@ -155,7 +155,7 @@ test('AI auto-selected destroy effects log their target', async () => {
   formatSpy.mockRestore();
 
   const lastLog = g.opponent.log[g.opponent.log.length - 1];
-  expect(lastLog).toBe(`Played ${spell.name} targeting ${target.name}`);
+  expect(lastLog).toBe(`5: Played ${spell.name} targeting ${target.name}`);
 });
 
 test('auto-target logging falls back when target capture is unavailable', async () => {
@@ -191,7 +191,7 @@ test('auto-target logging falls back when target capture is unavailable', async 
   g.recordActionTarget = originalRecord;
 
   const lastLog = g.player.log[g.player.log.length - 1];
-  expect(lastLog).toBe(`Played ${spell.name} targeting ${enemy.name}`);
+  expect(lastLog).toBe(`5: Played ${spell.name} targeting ${enemy.name}`);
 });
 
 test('AI secrets are obscured in combat log entries', async () => {
@@ -213,5 +213,5 @@ test('AI secrets are obscured in combat log entries', async () => {
   expect(ok).toBe(true);
 
   const lastLog = g.opponent.log[g.opponent.log.length - 1];
-  expect(lastLog).toBe('Played a secret');
+  expect(lastLog).toBe('5: Played a secret');
 });

--- a/__tests__/game.playFromHand.test.js
+++ b/__tests__/game.playFromHand.test.js
@@ -39,8 +39,8 @@ test('counter secret writes combat log entries when triggered', async () => {
   const played = await g.playFromHand(g.player, spell.id);
 
   expect(played).toBe(true);
-  expect(g.opponent.log).toContain('Secret triggered: Counter Shot');
-  expect(g.player.log).toContain('Enemy secret triggered: Counter Shot');
+  expect(g.opponent.log).toContain('1: Secret triggered: Counter Shot');
+  expect(g.player.log).toContain('1: Enemy secret triggered: Counter Shot');
 });
 
 test('countering a secret removes secret badges from both heroes', async () => {

--- a/__tests__/hero-power.log.test.js
+++ b/__tests__/hero-power.log.test.js
@@ -20,7 +20,7 @@ test('logs when player uses hero power', async () => {
 
   const ok = await g.useHeroPower(g.player);
   expect(ok).toBe(true);
-  expect(g.player.log[g.player.log.length - 1]).toBe('Used hero power');
+  expect(g.player.log[g.player.log.length - 1]).toBe('2: Used hero power');
 });
 
 test('logs when AI uses hero power', async () => {
@@ -35,5 +35,5 @@ test('logs when AI uses hero power', async () => {
 
   const ok = await g.useHeroPower(g.opponent);
   expect(ok).toBe(true);
-  expect(g.opponent.log[g.opponent.log.length - 1]).toBe('Used hero power');
+  expect(g.opponent.log[g.opponent.log.length - 1]).toBe('2: Used hero power');
 });

--- a/__tests__/systems.effects.test.js
+++ b/__tests__/systems.effects.test.js
@@ -112,8 +112,8 @@ describe('EffectSystem', () => {
     await game.effects.dealDamage({ target: 'selfHero', amount: 1 }, { game, player, card: null });
     await new Promise(r => setTimeout(r, 0));
 
-    expect(player.log).toContain('Secret triggered: Explosive Trap');
-    expect(opponent.log).toContain('Enemy secret triggered: Explosive Trap');
+    expect(player.log).toContain('1: Secret triggered: Explosive Trap');
+    expect(opponent.log).toContain('1: Enemy secret triggered: Explosive Trap');
 
     expect(player.hero.data.health).toBe(7);
     expect(opponent.hero.data.health).toBe(8);

--- a/__tests__/utils.savegame.test.js
+++ b/__tests__/utils.savegame.test.js
@@ -2,6 +2,7 @@ import Game from '../src/js/game.js';
 import Card from '../src/js/entities/card.js';
 import { getCardInstanceId } from '../src/js/utils/card.js';
 import { captureGameState, restoreCapturedState } from '../src/js/utils/savegame.js';
+import { appendLogEntry } from '../src/js/utils/combatLog.js';
 
 describe('savegame utilities', () => {
   test('capture and restore round trip', async () => {
@@ -15,7 +16,7 @@ describe('savegame utilities', () => {
     game.turns.turn = 3;
     game.turns.current = 'Main';
     game.resources._pool.set(game.player, 2);
-    game.player.log.push('Test entry');
+    appendLogEntry(game.player, 'Test entry', { turn: game.turns.turn });
 
     const snapshot = captureGameState(game);
     expect(snapshot).toBeTruthy();
@@ -25,7 +26,7 @@ describe('savegame utilities', () => {
     const ok = restoreCapturedState(clone, snapshot);
     expect(ok).toBe(true);
     expect(clone.player.hero.data.health).toBe(game.player.hero.data.health);
-    expect(clone.player.log.slice(-1)[0]).toBe('Test entry');
+    expect(clone.player.log.slice(-1)[0]).toBe('3: Test entry');
     expect(clone.turns.turn).toBe(3);
     expect(clone.turns.current).toBe('Main');
     expect(clone.resources.pool(clone.player)).toBe(2);

--- a/src/js/entities/player.js
+++ b/src/js/entities/player.js
@@ -19,6 +19,7 @@ export class Player {
     this.cardsPlayedThisTurn = 0;
     this.armorGainedThisTurn = 0;
     this.log = [];
+    this.logTurn = 1;
 
     this.library = new Deck('library');
     this.hand = new Hand('hand');
@@ -28,9 +29,9 @@ export class Player {
     this.removed = new Zone('removed');
   }
 
-  equip(item) {
+  equip(item, options = {}) {
     const eq = item instanceof Equipment ? item : new Equipment(item);
-    replaceEquipment(this, eq);
+    replaceEquipment(this, eq, options);
     return eq;
   }
 }

--- a/src/js/systems/ai-mcts.js
+++ b/src/js/systems/ai-mcts.js
@@ -1603,7 +1603,7 @@ export class MCTS_AI {
       if (played.type === 'ally' || played.type === 'equipment' || played.type === 'quest') {
         p.battlefield.cards.push(played);
         if (played.type === 'equipment') {
-          replaceEquipment(p, played);
+          replaceEquipment(p, played, { turn: this.resources?.turns?.turn ?? null });
         }
         if (played.type === 'ally') {
           removeOverflowAllies(p);
@@ -2516,7 +2516,9 @@ export class MCTS_AI {
           }
           if (action.card.type === 'ally' || action.card.type === 'equipment' || action.card.type === 'quest') {
             player.hand.moveTo(player.battlefield, action.card);
-            if (action.card.type === 'equipment') player.equip(action.card);
+            if (action.card.type === 'equipment') {
+              player.equip(action.card, { turn: this.resources?.turns?.turn ?? null });
+            }
             if (action.card.type === 'ally' && !action.card.keywords?.includes('Rush')) {
               action.card.data = action.card.data || {};
               action.card.data.attacked = true;

--- a/src/js/systems/ai-nn.js
+++ b/src/js/systems/ai-nn.js
@@ -8,6 +8,7 @@ import MLP from './nn.js';
 import { actionSignature } from './ai-signatures.js';
 import { encodeMinion, getLatentSize, loadAutoencoder } from './autoencoder.js';
 import { getCardInstanceId, matchesCardIdentifier } from '../utils/card.js';
+import { appendLogEntry } from '../utils/combatLog.js';
 
 export const HERO_ID_VOCAB = Object.freeze([
   'hero-anduin-wrynn-high-king-priest',
@@ -655,7 +656,9 @@ export class NeuralAI {
       data.attacksUsed = (data.attacksUsed || 0) + 1;
       if (attacker?.keywords?.includes?.('Stealth')) attacker.keywords = attacker.keywords.filter(k => k !== 'Stealth');
       if (block) this.combat.assignBlocker(getCardInstanceId(attacker), block);
-      player.log.push(`Attacked ${target.name} with ${attacker.name}`);
+      appendLogEntry(player, `Attacked ${target.name} with ${attacker.name}`, {
+        turn: this.game?.turns?.turn ?? this.resources?.turns?.turn ?? null,
+      });
 
       this.combat.setDefenderHero(opponent.hero);
       const events = this.combat.resolve();

--- a/src/js/systems/ai.js
+++ b/src/js/systems/ai.js
@@ -4,6 +4,7 @@ import { selectTargets } from './targeting.js';
 import Card from '../entities/card.js';
 import { cardsMatch, getCardInstanceId, matchesCardIdentifier } from '../utils/card.js';
 import { replaceEquipment } from '../utils/equipment.js';
+import { appendLogEntry } from '../utils/combatLog.js';
 import { removeOverflowAllies } from '../utils/allies.js';
 
 export class BasicAI {
@@ -263,7 +264,7 @@ export class BasicAI {
       if (played.type === 'ally' || played.type === 'equipment' || played.type === 'quest') {
         p.battlefield.cards.push(played);
         if (played.type === 'equipment') {
-          replaceEquipment(p, played);
+          replaceEquipment(p, played, { turn: this.resources?.turns?.turn ?? null });
         }
         if (played.type === 'ally') {
           removeOverflowAllies(p);
@@ -371,7 +372,9 @@ export class BasicAI {
       if (best.card.effects) this._applySimpleEffects(best.card.effects, player, opponent, pool);
       if (best.card.type === 'ally' || best.card.type === 'equipment' || best.card.type === 'quest') {
         player.hand.moveTo(player.battlefield, best.card);
-        if (best.card.type === 'equipment') player.equip(best.card);
+        if (best.card.type === 'equipment') {
+          player.equip(best.card, { turn: this.resources?.turns?.turn ?? null });
+        }
         if (best.card.type === 'ally') {
           best.card.data = best.card.data || {};
           best.card.data.enteredTurn = this.resources?.turns?.turn ?? 0;
@@ -391,7 +394,9 @@ export class BasicAI {
       this.resources.pay(player, 2);
       player.hero.powerUsed = true;
       if (player.hero.active) this._applySimpleEffects(player.hero.active, player, opponent, pool);
-      if (player?.log) player.log.push('Used hero power');
+      if (player?.log) {
+        appendLogEntry(player, 'Used hero power', { turn: this.resources?.turns?.turn ?? null });
+      }
     }
 
     if (this._shouldAbortTurn(player, opponent)) return true;

--- a/src/js/systems/effects.js
+++ b/src/js/systems/effects.js
@@ -2638,7 +2638,7 @@ export class EffectSystem {
     const { item } = effect;
     const { player, game } = context;
     const eq = new Equipment(item);
-    player.equip(eq);
+    player.equip(eq, { turn: game?.turns?.turn ?? null });
     if (eq.armor) {
       player.armorGainedThisTurn = (player.armorGainedThisTurn || 0) + eq.armor;
       game.bus.emit('armorGained', { player, amount: eq.armor, source: eq });

--- a/src/js/utils/combatLog.js
+++ b/src/js/utils/combatLog.js
@@ -1,5 +1,16 @@
 const SECRET_FALLBACK = 'Secret';
 
+export function appendLogEntry(owner, message, { turn = null } = {}) {
+  if (!owner || !Array.isArray(owner.log)) return;
+  if (message == null) return;
+  const resolvedTurn = Number.isFinite(turn)
+    ? Math.max(1, Math.trunc(turn))
+    : (Number.isFinite(owner?.logTurn) ? Math.max(1, Math.trunc(owner.logTurn)) : null);
+  const text = typeof message === 'string' ? message : String(message);
+  const entry = resolvedTurn != null ? `${resolvedTurn}: ${text}` : text;
+  owner.log.push(entry);
+}
+
 function formatSecretName(card, token) {
   if (card?.name) return card.name;
   const type = token?.type || token?.effect?.type;
@@ -19,10 +30,10 @@ function formatSecretName(card, token) {
 export function logSecretTriggered(game, owner, { card = null, token = null } = {}) {
   if (!game || !owner) return;
   const secretName = formatSecretName(card, token);
-  if (Array.isArray(owner.log)) owner.log.push(`Secret triggered: ${secretName}`);
+  appendLogEntry(owner, `Secret triggered: ${secretName}`, { turn: game?.turns?.turn });
   const opponent = owner === game.player ? game.opponent : game.player;
   if (opponent && Array.isArray(opponent.log)) {
-    opponent.log.push(`Enemy secret triggered: ${secretName}`);
+    appendLogEntry(opponent, `Enemy secret triggered: ${secretName}`, { turn: game?.turns?.turn });
   }
 }
 

--- a/src/js/utils/equipment.js
+++ b/src/js/utils/equipment.js
@@ -1,4 +1,5 @@
 import { cardsMatch, matchesCardIdentifier } from './card.js';
+import { appendLogEntry } from './combatLog.js';
 
 function removeFromZone(zone, card) {
   if (!zone || !card) return null;
@@ -34,7 +35,7 @@ function ensureHeroData(hero) {
   return hero.data;
 }
 
-export function destroyEquipment(owner, equipment, { replacement = null } = {}) {
+export function destroyEquipment(owner, equipment, { replacement = null, turn = null } = {}) {
   if (!owner?.hero || !equipment) return null;
   const { hero } = owner;
   if (Array.isArray(hero.equipment)) {
@@ -54,16 +55,16 @@ export function destroyEquipment(owner, equipment, { replacement = null } = {}) 
   if (Array.isArray(owner.log) && equipment?.name) {
     const replacementName = replacement?.name;
     if (replacementName) {
-      owner.log.push(`${equipment.name} was destroyed when ${replacementName} was equipped.`);
+      appendLogEntry(owner, `${equipment.name} was destroyed when ${replacementName} was equipped.`, { turn });
     } else {
-      owner.log.push(`${equipment.name} was destroyed.`);
+      appendLogEntry(owner, `${equipment.name} was destroyed.`, { turn });
     }
   }
 
   return card;
 }
 
-export function replaceEquipment(owner, newEquipment) {
+export function replaceEquipment(owner, newEquipment, { turn = null } = {}) {
   if (!owner?.hero) return newEquipment;
   const { hero } = owner;
   const current = Array.isArray(hero.equipment) ? hero.equipment : [];
@@ -72,7 +73,7 @@ export function replaceEquipment(owner, newEquipment) {
   if (current.length) {
     for (const eq of current) {
       if (!newEquipment || !cardsMatch(eq, newEquipment)) {
-        destroyEquipment(owner, eq, { replacement: newEquipment });
+        destroyEquipment(owner, eq, { replacement: newEquipment, turn });
       }
     }
   }


### PR DESCRIPTION
## Summary
- add a shared combat log helper that prefixes entries with the active turn and track the current turn on each player
- update game systems, AI logic, and equipment handling to write through the new helper so combat logs always include turn numbers
- adjust combat log related tests to expect prefixed entries and rely on the new logging helper

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5567e62b0832381f2bd02c92e5304