### PR TITLE
feat: empower silver hand recruits with lieutenant aura

### DIFF
--- a/__tests__/cards.effects.test.js
+++ b/__tests__/cards.effects.test.js
@@ -578,6 +578,38 @@ describe.each(effectCards)('$id executes its effect', (card) => {
         }
         break;
       }
+      case 'friendlyAuraBuff': {
+        const recruitA = new Card({
+          id: 'ally-silver-hand-recruit',
+          name: 'Silver Hand Recruit A',
+          type: 'ally',
+          data: { attack: 1, health: 1 },
+        });
+        const recruitB = new Card({
+          id: 'ally-silver-hand-recruit',
+          name: 'Silver Hand Recruit B',
+          type: 'ally',
+          data: { attack: 1, health: 1 },
+        });
+
+        g.player.battlefield.add(recruitA);
+        g.player.battlefield.add(recruitB);
+
+        await g.playFromHand(g.player, card.id);
+
+        expect(recruitA.data.attack).toBe(1 + effect.amount);
+        expect(recruitB.data.attack).toBe(1 + effect.amount);
+
+        const lieutenant = g.player.battlefield.cards.find(c => c.id === card.id);
+        if (lieutenant) {
+          g.player.battlefield.remove(lieutenant);
+          g.bus.emit('allyDefeated', { player: g.player, card: lieutenant });
+        }
+
+        expect(recruitA.data.attack).toBe(1);
+        expect(recruitB.data.attack).toBe(1);
+        break;
+      }
       default:
         throw new Error('Unhandled effect type: ' + effect.type);
     }

--- a/__tests__/silver-hand-lieutenant.aura.test.js
+++ b/__tests__/silver-hand-lieutenant.aura.test.js
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+
+const allyCards = JSON.parse(fs.readFileSync(new URL('../data/cards/ally.json', import.meta.url)));
+const lieutenantData = allyCards.find((c) => c.id === 'ally-silver-hand-lieutenant');
+const recruitData = allyCards.find((c) => c.id === 'ally-silver-hand-recruit');
+
+test('Silver Hand Lieutenant grants +1 attack to each recruit per friendly lieutenant', async () => {
+  expect(lieutenantData).toBeDefined();
+  expect(recruitData).toBeDefined();
+
+  const game = new Game();
+  await game.setupMatch();
+
+  const player = game.player;
+  player.hand.cards = [];
+  player.battlefield.cards = [];
+  game.resources._pool.set(player, 20);
+
+  const recruitOne = new Card(recruitData);
+  recruitOne.owner = player;
+  player.hand.add(recruitOne);
+  await game.playFromHand(player, recruitOne.id);
+  expect(recruitOne.data.attack).toBe(1);
+
+  const lieutenantOne = new Card(lieutenantData);
+  lieutenantOne.owner = player;
+  player.hand.add(lieutenantOne);
+  await game.playFromHand(player, lieutenantOne.id);
+  expect(recruitOne.data.attack).toBe(2);
+
+  const recruitTwo = new Card(recruitData);
+  recruitTwo.owner = player;
+  player.hand.add(recruitTwo);
+  await game.playFromHand(player, recruitTwo.id);
+  expect(recruitTwo.data.attack).toBe(2);
+
+  const lieutenantTwo = new Card(lieutenantData);
+  lieutenantTwo.owner = player;
+  player.hand.add(lieutenantTwo);
+  await game.playFromHand(player, lieutenantTwo.id);
+
+  expect(recruitOne.data.attack).toBe(3);
+  expect(recruitTwo.data.attack).toBe(3);
+
+  player.battlefield.remove(lieutenantOne);
+  game.bus.emit('allyDefeated', { player, card: lieutenantOne });
+  expect(recruitOne.data.attack).toBe(2);
+  expect(recruitTwo.data.attack).toBe(2);
+
+  player.battlefield.remove(lieutenantTwo);
+  game.bus.emit('allyDefeated', { player, card: lieutenantTwo });
+  expect(recruitOne.data.attack).toBe(1);
+  expect(recruitTwo.data.attack).toBe(1);
+});

--- a/data/cards/ally.json
+++ b/data/cards/ally.json
@@ -23,8 +23,12 @@
     "cost": 3,
     "effects": [
       {
-        "type": "rawText",
-        "text": "Your Recruits have +1 ATK."
+        "type": "friendlyAuraBuff",
+        "property": "attack",
+        "amount": 1,
+        "targetCardIds": [
+          "ally-silver-hand-recruit"
+        ]
       }
     ],
     "keywords": [


### PR DESCRIPTION
## Summary
- add a reusable friendlyAuraBuff effect that applies continuous buffs to targeted allies
- update Silver Hand Lieutenant to use the aura and empower Silver Hand Recruits
- expand test coverage with new aura tests and cards.effects handling for the new effect type

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55bde5c688323b4a1bc6b0061200e