### PR TITLE
fix: stop mcts ai rushing face

### DIFF
--- a/__tests__/ai.mcts.rush-face.test.js
+++ b/__tests__/ai.mcts.rush-face.test.js
@@ -1,0 +1,54 @@
+import Game from '../src/js/game.js';
+import Card from '../src/js/entities/card.js';
+import MCTS_AI from '../src/js/systems/ai-mcts.js';
+
+test('MCTS AI respects Rush restriction on hero attacks', async () => {
+  const game = new Game();
+  const ai = new MCTS_AI({
+    resourceSystem: game.resources,
+    combatSystem: game.combat,
+    game,
+    iterations: 50,
+    rolloutDepth: 2,
+  });
+
+  game.turns.turn = 5;
+  game.turns.setActivePlayer(game.opponent);
+
+  game.opponent.hero.active = [];
+  game.opponent.hand.cards = [];
+  game.opponent.library.cards = [];
+  game.opponent.log = [];
+
+  const rushAlly = new Card({
+    id: 'ai-test-rush',
+    type: 'ally',
+    name: 'AI Rush Ally',
+    keywords: ['Rush'],
+    cost: 3,
+    data: {
+      attack: 4,
+      health: 4,
+      maxHealth: 4,
+      enteredTurn: game.turns.turn,
+      summoningSick: false,
+      attacked: false,
+      attacksUsed: 0,
+    },
+  });
+  rushAlly.owner = game.opponent;
+
+  game.opponent.battlefield.cards = [rushAlly];
+  game.player.battlefield.cards = [];
+
+  game.player.hero.data.maxHealth = 30;
+  game.player.hero.data.health = 18;
+  game.player.hero.data.armor = 0;
+
+  await ai.takeTurn(game.opponent, game.player);
+
+  expect(game.player.hero.data.health).toBe(18);
+  expect(rushAlly.data.attacksUsed || 0).toBe(0);
+  const rushAttacks = game.opponent.log.filter(entry => entry.includes('with AI Rush Ally'));
+  expect(rushAttacks).toHaveLength(0);
+});

--- a/src/js/systems/ai-mcts.js
+++ b/src/js/systems/ai-mcts.js
@@ -1109,8 +1109,10 @@ export class MCTS_AI {
       }
     }
 
-    if (!bestTarget && heroEligible && hero) return hero;
-    if (!bestTarget) return defenders[0] || null;
+    if (!bestTarget) {
+      if (heroEligible && hero) return hero;
+      return defenders.find(target => !matchesCardIdentifier(target, hero)) || null;
+    }
     return bestTarget;
   }
 


### PR DESCRIPTION
## Summary
- prevent the MCTS target selector from falling back to the hero when that attack is illegal for freshly-summoned Rush units
- add a regression test ensuring the MCTS AI cannot attack the opposing hero with a Rush ally the turn it enters play

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5677394848323830bcb5a92e62a4d