### PR TITLE
feat: enlarge enemy cards on touch

### DIFF
--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -134,17 +134,20 @@ function setTouchPreview(el) {
   }
   touchPreviewCardEl = el;
   el.dataset.touchPreview = '1';
-  if (typeof window !== 'undefined' && el.dataset?.type === 'ally' && el.closest('.p-field')) {
-    const rect = el.getBoundingClientRect();
-    const centerX = window.innerWidth / 2;
-    const centerY = window.innerHeight / 2;
-    const elCenterX = rect.left + rect.width / 2;
-    const elCenterY = rect.top + rect.height / 2;
-    const offsetX = Number.isFinite(elCenterX) ? (centerX - elCenterX) : 0;
-    const offsetY = Number.isFinite(elCenterY) ? (centerY - elCenterY) : 0;
-    if (el.style) {
-      el.style.setProperty('--touch-translate-x', `${offsetX}px`);
-      el.style.setProperty('--touch-translate-y', `${offsetY}px`);
+  if (typeof window !== 'undefined') {
+    const boardCardRoot = el.closest('.p-field, .ai-field, .slot.ai-hero, .slot.p-hero');
+    if (boardCardRoot) {
+      const rect = el.getBoundingClientRect();
+      const centerX = window.innerWidth / 2;
+      const centerY = window.innerHeight / 2;
+      const elCenterX = rect.left + rect.width / 2;
+      const elCenterY = rect.top + rect.height / 2;
+      const offsetX = Number.isFinite(elCenterX) ? (centerX - elCenterX) : 0;
+      const offsetY = Number.isFinite(elCenterY) ? (centerY - elCenterY) : 0;
+      if (el.style) {
+        el.style.setProperty('--touch-translate-x', `${offsetX}px`);
+        el.style.setProperty('--touch-translate-y', `${offsetY}px`);
+      }
     }
   }
   if (touchPreviewTimer) clearTimeout(touchPreviewTimer);

--- a/styles.css
+++ b/styles.css
@@ -147,7 +147,18 @@ main {
   transform-origin: center center;
 }
 
-.p-field .card-tooltip[data-touch-preview='1'] {
+.ai-field .card-tooltip,
+.slot.ai-hero .card-tooltip,
+.slot.p-hero .card-tooltip {
+  transition: transform 0.3s ease, filter 0.3s ease, z-index 0.3s ease;
+  will-change: transform;
+  transform-origin: center center;
+}
+
+.ai-field .card-tooltip[data-touch-preview='1'],
+.p-field .card-tooltip[data-touch-preview='1'],
+.slot.ai-hero .card-tooltip[data-touch-preview='1'],
+.slot.p-hero .card-tooltip[data-touch-preview='1'] {
   transform: translate3d(var(--touch-translate-x, 0), var(--touch-translate-y, 0), 0) scale(1.5);
   z-index: 1500;
   filter: drop-shadow(0 30px 60px rgba(0, 0, 0, 0.75));


### PR DESCRIPTION
## Summary
- allow touch previews to translate and enlarge any board card, including enemy allies and both heroes
- extend styling so enemy cards and heroes animate to the foreground when touched

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d569f8aa488323bfca1205bcfa351c