### PR TITLE
feat: allow choosing opponent deck in builder

### DIFF
--- a/__tests__/ui.deckbuilder.test.js
+++ b/__tests__/ui.deckbuilder.test.js
@@ -50,13 +50,40 @@ describe('deckbuilder UI', () => {
     const onSelect = jest.fn();
     const rerender = () => renderDeckBuilder(container, { state, allCards, onChange: rerender, prebuiltDecks, onSelectPrebuilt: onSelect });
     rerender();
-    const select = container.querySelector('select');
+    const select = container.querySelector('select[data-role="prebuilt-deck-select"]');
     expect(select).not.toBeNull();
     expect(Array.from(select.options).map(opt => opt.value)).toContain('starter');
     expect(Array.from(select.options).map(opt => opt.textContent)).toContain('starter (Valeera)');
     select.value = 'starter';
     select.dispatchEvent(new window.Event('change'));
     expect(onSelect).toHaveBeenCalledWith('starter');
+  });
+
+  test('opponent dropdown lists heroes and triggers callback', () => {
+    const hero1 = { id: 'h1', name: 'Valeera', type: 'hero', text: '', data: { armor: 0 } };
+    const hero2 = { id: 'h2', name: 'Thrall', type: 'hero', text: '', data: { armor: 0 } };
+    const ally = { id: 'a1', name: 'Ally', type: 'ally', text: '', cost: 1, data: { attack: 1, health: 1 } };
+    const allCards = [hero1, hero2, ally];
+    const state = { hero: null, cards: [], selectedOpponentHeroId: null };
+    const container = document.createElement('div');
+    const onSelectOpponent = jest.fn();
+    const rerender = () => renderDeckBuilder(container, {
+      state,
+      allCards,
+      onChange: rerender,
+      onSelectOpponent,
+    });
+    rerender();
+    const select = container.querySelector('select[data-role="opponent-deck-select"]');
+    expect(select).not.toBeNull();
+    const optionValues = Array.from(select.options).map(opt => opt.value);
+    expect(optionValues).toContain('');
+    expect(optionValues).toContain('h1');
+    expect(optionValues).toContain('h2');
+    expect(select.options[0].textContent).toBe('Random');
+    select.value = 'h2';
+    select.dispatchEvent(new window.Event('change'));
+    expect(onSelectOpponent).toHaveBeenCalledWith('h2');
   });
 
   test('adding a card clears prefab selection state', () => {

--- a/__tests__/ui.fill-random-button.test.js
+++ b/__tests__/ui.fill-random-button.test.js
@@ -46,7 +46,7 @@ test('fill random button fills hero and 60 cards and enables use', async () => {
   main.append(root, sidebar);
   document.body.append(main);
 
-  const deckState = { hero: null, cards: [] };
+  const deckState = { hero: null, cards: [], selectedOpponentHeroId: null };
   const toggleGameVisible = (show) => {
     board.style.display = show ? 'block' : 'none';
     root.style.display = show ? 'block' : 'none';
@@ -55,8 +55,18 @@ test('fill random button fills hero and 60 cards and enables use', async () => {
   function updateUseDeckBtn() {
     useDeckBtn.disabled = !(deckState.hero && deckState.cards.length === 60);
   }
-  const rerenderDeck = () => {
-    renderDeckBuilder(deckRoot, { state: deckState, allCards: game.allCards, onChange: rerenderDeck });
+  let rerenderDeck = () => {};
+  const onSelectOpponent = (heroId) => {
+    deckState.selectedOpponentHeroId = heroId;
+    rerenderDeck();
+  };
+  rerenderDeck = () => {
+    renderDeckBuilder(deckRoot, {
+      state: deckState,
+      allCards: game.allCards,
+      onChange: rerenderDeck,
+      onSelectOpponent,
+    });
     updateUseDeckBtn();
   };
 
@@ -74,7 +84,9 @@ test('fill random button fills hero and 60 cards and enables use', async () => {
     if (useDeckBtn.disabled) return;
     deckRoot.style.display = 'none';
     toggleGameVisible(true);
-    await game.reset({ hero: deckState.hero, cards: deckState.cards });
+    const payload = { hero: deckState.hero, cards: deckState.cards };
+    if (deckState.selectedOpponentHeroId) payload.opponentHeroId = deckState.selectedOpponentHeroId;
+    await game.reset(payload);
   });
 
   // Open deck builder


### PR DESCRIPTION
## Summary
- add an opponent deck selector to the deck builder UI that lists all heroes and defaults to Random
- plumb the selected opponent hero through the deck builder state so game resets use that hero for the AI deck
- expand deck builder-related tests to cover the new selector, state handling, and reset payloads

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5919ed36083239b03d5184d842c66