### PR TITLE
feat: add start screens for hero selection

### DIFF
--- a/__tests__/game.reset.opponent-deck.test.js
+++ b/__tests__/game.reset.opponent-deck.test.js
@@ -1,0 +1,51 @@
+import Game from '../src/js/game.js';
+
+describe('Game.reset with explicit opponent deck', () => {
+  test('uses provided opponent hero and deck', async () => {
+    const game = new Game();
+    await game.setupMatch();
+
+    const prebuilt = await game.getPrebuiltDecks();
+    expect(Array.isArray(prebuilt)).toBe(true);
+    expect(prebuilt.length).toBeGreaterThan(0);
+    const playerDeck = prebuilt[0];
+    expect(playerDeck?.hero).toBeTruthy();
+    expect(playerDeck?.cards?.length).toBe(60);
+    const opponentDeck = prebuilt.find((deck) => deck?.hero?.id !== playerDeck.hero.id)
+      || prebuilt[0];
+    expect(opponentDeck?.hero).toBeTruthy();
+    expect(opponentDeck?.cards?.length).toBe(60);
+
+    await game.reset({
+      hero: playerDeck.hero,
+      cards: playerDeck.cards,
+      opponentDeck: {
+        hero: opponentDeck.hero,
+        cards: opponentDeck.cards,
+      },
+    });
+
+    expect(game.player.hero?.id).toBe(playerDeck.hero.id);
+    expect(game.opponent.hero?.id).toBe(opponentDeck.hero.id);
+
+    const playerLibraryIds = game.player.library.cards.map((card) => card.id);
+    const expectedPlayerIds = playerDeck.cards.map((card) => card.id);
+    const playerIdSet = new Set(playerLibraryIds);
+    const expectedPlayerIdSet = new Set(expectedPlayerIds);
+    expect(playerIdSet).toEqual(expectedPlayerIdSet);
+    expect(playerLibraryIds.length).toBeGreaterThanOrEqual(expectedPlayerIdSet.size);
+    expect(playerLibraryIds.length).toBeLessThanOrEqual(expectedPlayerIds.length);
+    expect(playerLibraryIds.every((id) => expectedPlayerIdSet.has(id))).toBe(true);
+
+    const opponentLibraryIds = game.opponent.library.cards.map((card) => card.id);
+    const expectedOpponentIds = opponentDeck.cards.map((card) => card.id);
+    const opponentIdSet = new Set(opponentLibraryIds);
+    const expectedOpponentIdSet = new Set(expectedOpponentIds);
+    expect(opponentIdSet).toEqual(expectedOpponentIdSet);
+    expect(opponentLibraryIds.length).toBeGreaterThanOrEqual(expectedOpponentIdSet.size);
+    expect(opponentLibraryIds.length).toBeLessThanOrEqual(expectedOpponentIds.length);
+    expect(opponentLibraryIds.every((id) => expectedOpponentIdSet.has(id))).toBe(true);
+
+    expect(game.state.lastOpponentHeroId).toBe(opponentDeck.hero.id);
+  });
+});

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -396,8 +396,22 @@ export default class Game {
     this._pendingTurnIncrement = false;
 
     let forcedOpponentHero = null;
+    let forcedOpponentDeck = null;
     let desiredOpponentHeroId = null;
-    if (playerDeck && playerDeck.opponentHeroId != null) {
+    if (playerDeck && playerDeck.opponentDeck) {
+      const deckHero = playerDeck.opponentDeck?.hero;
+      if (deckHero && deckHero.type === 'hero') {
+        forcedOpponentHero = deckHero;
+        desiredOpponentHeroId = deckHero?.id ? String(deckHero.id) : null;
+      }
+      const deckCards = Array.isArray(playerDeck.opponentDeck?.cards)
+        ? playerDeck.opponentDeck.cards.slice()
+        : [];
+      forcedOpponentDeck = {
+        hero: (deckHero && deckHero.type === 'hero') ? deckHero : null,
+        cards: deckCards,
+      };
+    } else if (playerDeck && playerDeck.opponentHeroId != null) {
       desiredOpponentHeroId = String(playerDeck.opponentHeroId);
       if (desiredOpponentHeroId) {
         const candidate = cardById.get(desiredOpponentHeroId);
@@ -547,7 +561,14 @@ export default class Game {
 
     // Assign opponent hero and library
     let opponentDeckState = null;
-    if (opponentIsAI) {
+    if (forcedOpponentDeck) {
+      opponentDeckState = {
+        hero: forcedOpponentDeck.hero,
+        cards: Array.isArray(forcedOpponentDeck.cards)
+          ? forcedOpponentDeck.cards.slice()
+          : [],
+      };
+    } else if (opponentIsAI) {
       opponentDeckState = pickPrebuiltDeck(this.player.hero?.id);
     }
     if (!opponentDeckState) {

--- a/styles.css
+++ b/styles.css
@@ -44,6 +44,177 @@ main {
   align-content: start;
 }
 
+#start-screen-root {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 6vw, 64px);
+  background: radial-gradient(circle at top, rgba(12, 18, 26, 0.96), rgba(6, 9, 14, 0.96));
+  z-index: 300;
+  overflow-y: auto;
+}
+
+#start-screen-root[aria-hidden="false"] {
+  display: flex;
+}
+
+.start-screen-panel {
+  width: min(960px, 100%);
+  max-width: 100%;
+  background: linear-gradient(180deg, rgba(18, 24, 34, 0.95), rgba(9, 12, 18, 0.95));
+  border: 1px solid rgba(200, 155, 60, 0.45);
+  border-radius: 16px;
+  padding: clamp(24px, 5vw, 48px);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: clamp(16px, 4vw, 32px);
+  color: #f4e7c6;
+}
+
+.start-screen-panel h2 {
+  margin: 0;
+  font-size: clamp(28px, 4vw, 38px);
+  text-align: center;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.start-screen-panel p {
+  margin: 0;
+  font-size: clamp(16px, 2vw, 18px);
+  line-height: 1.5;
+  text-align: center;
+}
+
+.start-screen-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+}
+
+.start-screen-actions button {
+  font-size: clamp(16px, 2vw, 18px);
+  padding: 12px 24px;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(180deg, #f6d76b, #c7962c);
+  color: #1b1206;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.start-screen-actions button:hover,
+.start-screen-actions button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
+  outline: none;
+}
+
+.start-screen-actions button:focus-visible {
+  outline: 2px solid #f6d76b;
+}
+
+.start-screen-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.start-screen-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  background: rgba(18, 24, 34, 0.9);
+  border: 1px solid transparent;
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: left;
+  color: #f4e7c6;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  min-height: 220px;
+}
+
+.start-screen-hero:hover,
+.start-screen-hero:focus {
+  border-color: rgba(200, 155, 60, 0.7);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.start-screen-hero:focus-visible {
+  outline: 2px solid rgba(200, 155, 60, 0.8);
+}
+
+.start-screen-hero[data-same-hero='1'] {
+  border-color: rgba(120, 180, 255, 0.6);
+}
+
+.start-screen-hero-art {
+  width: 100%;
+  max-height: 180px;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid rgba(200, 155, 60, 0.25);
+}
+
+.start-screen-hero-name {
+  font-size: clamp(18px, 3vw, 20px);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.start-screen-hero-deck {
+  font-size: clamp(14px, 2vw, 16px);
+  color: #f6d76b;
+  letter-spacing: 0.04em;
+}
+
+.start-screen-hero-text {
+  font-size: clamp(13px, 1.8vw, 15px);
+  color: #d8cfb1;
+  flex-grow: 1;
+}
+
+.start-screen-back {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid rgba(200, 155, 60, 0.6);
+  border-radius: 999px;
+  color: #f6d76b;
+  font-size: 14px;
+  letter-spacing: 0.06em;
+  padding: 6px 16px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.start-screen-back:hover,
+.start-screen-back:focus {
+  background: rgba(200, 155, 60, 0.15);
+  outline: none;
+}
+
+.start-screen-note {
+  font-size: 14px;
+  color: #c7b890;
+  text-align: center;
+}
+
+.start-screen-error {
+  font-size: 14px;
+  color: #ffb4b4;
+  text-align: center;
+}
+
 /* Hide sidebar by default; shown when deck builder is active */
 #sidebar {
   display: none;


### PR DESCRIPTION
## Summary
- add a multi-step start screen so players can resume saved games or choose new heroes before play begins
- ensure the game engine can load a specific opponent deck when resetting matches
- style the new overlays and cover the opponent deck workflow with a regression test

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d790fa68308323b2123f2f59da0e2f