### PR TITLE
feat: add start screen hero selection

### DIFF
--- a/__tests__/game.opponent-deck.test.js
+++ b/__tests__/game.opponent-deck.test.js
@@ -1,0 +1,59 @@
+import Game from '../src/js/game.js';
+
+describe('Game opponent deck selection', () => {
+  test('reset uses supplied opponent deck when provided', async () => {
+    const game = new Game(null);
+    await game.init();
+
+    const prebuiltDecks = await game.getPrebuiltDecks();
+    expect(prebuiltDecks.length).toBeGreaterThan(1);
+
+    const playerDeck = prebuiltDecks[0];
+    const opponentDeck = prebuiltDecks.find((deck) => deck?.hero?.id !== playerDeck?.hero?.id) || prebuiltDecks[1];
+
+    const deckOverride = {
+      hero: playerDeck.hero,
+      cards: Array.isArray(playerDeck.cards) ? playerDeck.cards.slice() : [],
+      opponentDeck: {
+        hero: opponentDeck.hero,
+        cards: Array.isArray(opponentDeck.cards) ? opponentDeck.cards.slice() : [],
+      },
+    };
+
+    await game.reset(deckOverride);
+
+    expect(game.player.hero.id).toBe(playerDeck.hero.id);
+    expect(game.opponent.hero.id).toBe(opponentDeck.hero.id);
+
+    const countById = (cards) => {
+      const counts = new Map();
+      for (const card of cards) {
+        if (!card?.id) continue;
+        counts.set(card.id, (counts.get(card.id) || 0) + 1);
+      }
+      return counts;
+    };
+
+    const playerExpected = countById(playerDeck.cards);
+    const playerAllCards = [...game.player.library.cards, ...game.player.hand.cards];
+    const playerActual = countById(playerAllCards);
+    expect(playerAllCards).toHaveLength(60);
+    expect(playerAllCards.every((card) => !!card?.id)).toBe(true);
+    for (const [id, count] of playerActual) {
+      expect(playerExpected.has(id)).toBe(true);
+      expect(count).toBeLessThanOrEqual(playerExpected.get(id));
+    }
+
+    const opponentExpected = countById(opponentDeck.cards);
+    const opponentAllCards = [...game.opponent.library.cards, ...game.opponent.hand.cards];
+    const opponentActual = countById(opponentAllCards);
+    expect(opponentAllCards).toHaveLength(60);
+    expect(opponentAllCards.every((card) => !!card?.id)).toBe(true);
+    for (const [id, count] of opponentActual) {
+      expect(opponentExpected.has(id)).toBe(true);
+      expect(count).toBeLessThanOrEqual(opponentExpected.get(id));
+    }
+
+    expect(game.state.lastOpponentHeroId).toBe(opponentDeck.hero.id);
+  });
+});

--- a/src/js/ui/startScreen.js
+++ b/src/js/ui/startScreen.js
@@ -1,3 +1,5 @@
+import { cardTooltip } from './cardTooltip.js';
+
 const noop = () => {};
 
 const schedule = (() => {
@@ -117,12 +119,29 @@ function renderHeroGrid({
   const children = [];
   if (Array.isArray(heroes) && heroes.length) {
     for (const hero of heroes) {
+      const heroId = hero?.id;
+      const heroName = hero?.name || 'Unknown Hero';
+      const baseCard = (hero && typeof hero === 'object') ? hero : {};
+      const tooltipCard = cardTooltip({
+        ...baseCard,
+        type: baseCard.type || 'hero',
+        id: heroId || 'unknown-hero',
+        name: heroName,
+        text: baseCard.text || '',
+      });
+      tooltipCard.dataset.startScreenCard = '1';
+      const ariaAttrs = { label: heroName };
+      if (selectedId != null) {
+        ariaAttrs.pressed = heroId && heroId === selectedId ? 'true' : 'false';
+      }
       const btn = el('button', {
         class: 'start-screen__hero',
         onclick: () => onSelect(hero),
-        dataset: { selected: hero?.id && hero.id === selectedId ? '1' : '0' },
+        dataset: { selected: heroId && heroId === selectedId ? '1' : '0' },
+        aria: ariaAttrs,
       },
-      el('span', { class: 'start-screen__hero-name' }, hero?.name || 'Unknown Hero'),
+      el('span', { class: 'start-screen__hero-card' }, tooltipCard),
+      el('span', { class: 'start-screen__hero-name' }, heroName),
       hero?.text ? el('span', { class: 'start-screen__hero-text' }, hero.text) : null);
       children.push(btn);
     }

--- a/src/js/ui/startScreen.js
+++ b/src/js/ui/startScreen.js
@@ -1,0 +1,263 @@
+const noop = () => {};
+
+const schedule = (() => {
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    return (cb) => window.requestAnimationFrame(cb);
+  }
+  return (cb) => setTimeout(cb, 16);
+})();
+
+function focusFirstChild(container) {
+  if (!container) return;
+  const attemptFocus = () => {
+    const preferred = container.querySelector('[data-auto-focus="1"]');
+    if (preferred && typeof preferred.focus === 'function') {
+      preferred.focus();
+      return;
+    }
+    const fallback = container.querySelector(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    if (fallback && typeof fallback.focus === 'function') {
+      fallback.focus();
+      return;
+    }
+    container.focus?.();
+  };
+  schedule(() => attemptFocus());
+}
+
+function el(tag, attrs = {}, ...children) {
+  const node = document.createElement(tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key === 'class') node.className = value;
+    else if (key === 'dataset' && value && typeof value === 'object') Object.assign(node.dataset, value);
+    else if (key.startsWith('on') && typeof value === 'function') node.addEventListener(key.slice(2), value);
+    else if (value == null || value === false) continue;
+    else if (key === 'disabled' || typeof value === 'boolean') node[key] = Boolean(value);
+    else if (key === 'aria') {
+      for (const [ariaKey, ariaValue] of Object.entries(value || {})) {
+        if (ariaValue == null) continue;
+        node.setAttribute(`aria-${ariaKey}`, ariaValue);
+      }
+    } else node.setAttribute(key, value);
+  }
+  for (const child of children) {
+    if (child == null || child === false) continue;
+    node.append(child.nodeType ? child : document.createTextNode(String(child)));
+  }
+  return node;
+}
+
+function uniqueHeroesFromDecks(decks = []) {
+  const list = [];
+  const seen = new Set();
+  for (const deck of decks) {
+    const hero = deck?.hero;
+    const id = hero?.id;
+    if (!hero || typeof id !== 'string') continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    list.push(hero);
+  }
+  list.sort((a, b) => {
+    const nameA = typeof a?.name === 'string' ? a.name : '';
+    const nameB = typeof b?.name === 'string' ? b.name : '';
+    return nameA.localeCompare(nameB, undefined, { numeric: true });
+  });
+  return list;
+}
+
+function renderInitialStep({
+  hasSavedGame,
+  onContinue = noop,
+  onRequestNewGame = noop,
+}) {
+  const buttons = [];
+  if (hasSavedGame) {
+    buttons.push(el('button', {
+      class: 'start-screen__button',
+      dataset: { autoFocus: buttons.length === 0 ? '1' : '0' },
+      onclick: onContinue,
+    }, 'Continue'));
+  }
+  const newGameButton = el('button', {
+    class: 'start-screen__button start-screen__button--primary',
+    dataset: { autoFocus: buttons.length === 0 ? '1' : '0' },
+    onclick: onRequestNewGame,
+  }, 'New Game');
+  buttons.push(newGameButton);
+  return el('div', {
+    class: 'start-screen__panel',
+    role: 'dialog',
+    tabindex: '-1',
+    aria: {
+      modal: 'true',
+      labelledby: 'start-screen-title',
+      describedby: 'start-screen-subtitle',
+    },
+  },
+    el('h2', { class: 'start-screen__title', id: 'start-screen-title' }, 'WoW Legends'),
+    el('p', { class: 'start-screen__subtitle', id: 'start-screen-subtitle' }, 'Embark on a new adventure or continue your journey.'),
+    el('div', { class: 'start-screen__actions' }, ...buttons),
+  );
+}
+
+function renderHeroGrid({
+  heroes,
+  onSelect = noop,
+  selectedId = null,
+  heading,
+  description,
+  onBack = null,
+  loading = false,
+  headingId = 'start-screen-hero-title',
+  subtitleId = 'start-screen-hero-subtitle',
+}) {
+  const children = [];
+  if (Array.isArray(heroes) && heroes.length) {
+    for (const hero of heroes) {
+      const btn = el('button', {
+        class: 'start-screen__hero',
+        onclick: () => onSelect(hero),
+        dataset: { selected: hero?.id && hero.id === selectedId ? '1' : '0' },
+      },
+      el('span', { class: 'start-screen__hero-name' }, hero?.name || 'Unknown Hero'),
+      hero?.text ? el('span', { class: 'start-screen__hero-text' }, hero.text) : null);
+      children.push(btn);
+    }
+  } else if (loading) {
+    children.push(el('p', { class: 'start-screen__empty' }, 'Loading heroes…'));
+  } else {
+    children.push(el('p', { class: 'start-screen__empty' }, 'No heroes available.'));
+  }
+
+  const footerButtons = [];
+  if (typeof onBack === 'function') {
+    footerButtons.push(el('button', { class: 'start-screen__button', onclick: onBack }, 'Back'));
+  }
+
+  const focusableButtons = children.filter((child) => child?.tagName === 'BUTTON');
+  const selectedButton = focusableButtons.find((child) => child.dataset?.selected === '1');
+  if (selectedButton) {
+    selectedButton.dataset.autoFocus = '1';
+  } else if (focusableButtons[0]) {
+    focusableButtons[0].dataset.autoFocus = '1';
+  }
+
+  if (!focusableButtons.length && footerButtons[0]) {
+    footerButtons[0].dataset.autoFocus = '1';
+  }
+
+  return el('div', {
+    class: 'start-screen__panel',
+    role: 'dialog',
+    tabindex: '-1',
+    aria: {
+      modal: 'true',
+      labelledby: headingId,
+      describedby: description ? subtitleId : null,
+    },
+  },
+    el('h2', { class: 'start-screen__title', id: headingId }, heading || 'Choose a hero'),
+    description ? el('p', { class: 'start-screen__subtitle', id: subtitleId }, description) : null,
+    el('div', { class: 'start-screen__hero-grid' }, ...children),
+    footerButtons.length ? el('div', { class: 'start-screen__actions' }, ...footerButtons) : null,
+  );
+}
+
+export function renderStartScreen(container, {
+  visible = false,
+  step = 'initial',
+  hasSavedGame = false,
+  decks = [],
+  selectedHeroId = null,
+  loadingDecks = false,
+  onContinue = noop,
+  onRequestNewGame = noop,
+  onSelectHero = noop,
+  onSelectOpponent = noop,
+  onBack = noop,
+  opponentContext = null,
+} = {}) {
+  if (!container) return;
+  container.classList.add('start-screen');
+  container.innerHTML = '';
+  container.style.display = visible ? 'flex' : 'none';
+  container.setAttribute('aria-hidden', visible ? 'false' : 'true');
+  if (!visible) {
+    container.dataset.currentStep = '';
+    if (container._startScreenKeydownHandler) {
+      container.removeEventListener('keydown', container._startScreenKeydownHandler);
+      container._startScreenKeydownHandler = null;
+    }
+    return;
+  }
+
+  const keydownHandler = (event) => {
+    if (event.defaultPrevented) return;
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    if (step === 'opponent') {
+      onBack?.('hero');
+    } else if (step === 'hero') {
+      onBack?.('initial');
+    } else {
+      onBack?.('close');
+    }
+  };
+
+  if (container._startScreenKeydownHandler) {
+    container.removeEventListener('keydown', container._startScreenKeydownHandler);
+  }
+  container._startScreenKeydownHandler = keydownHandler;
+  container.addEventListener('keydown', keydownHandler);
+
+  container.dataset.currentStep = step;
+
+  if (step === 'initial') {
+    const panel = renderInitialStep({ hasSavedGame, onContinue, onRequestNewGame });
+    container.append(panel);
+    focusFirstChild(panel);
+    return;
+  }
+
+  const heroes = uniqueHeroesFromDecks(decks);
+  if (step === 'hero') {
+    const panel = renderHeroGrid({
+      heroes,
+      loading: loadingDecks,
+      onSelect: (hero) => onSelectHero?.(hero),
+      heading: 'Choose your hero',
+      description: 'Select the champion you will lead into battle.',
+      onBack: () => onBack?.('initial'),
+      headingId: 'start-screen-hero-title',
+      subtitleId: 'start-screen-hero-subtitle',
+    });
+    container.append(panel);
+    focusFirstChild(panel);
+    return;
+  }
+
+  if (step === 'opponent') {
+    let subtitle = 'Select the foe you wish to challenge.';
+    if (opponentContext?.playerHeroName) {
+      subtitle = `Choose who will oppose ${opponentContext.playerHeroName}.`;
+    }
+    const panel = renderHeroGrid({
+      heroes,
+      loading: loadingDecks,
+      selectedId: opponentContext?.selectedOpponentId || null,
+      onSelect: (hero) => onSelectOpponent?.(hero),
+      heading: 'Choose your opponent',
+      description: subtitle,
+      onBack: () => onBack?.('hero'),
+      headingId: 'start-screen-opponent-title',
+      subtitleId: 'start-screen-opponent-subtitle',
+    });
+    container.append(panel);
+    focusFirstChild(panel);
+  }
+}
+
+export default renderStartScreen;

--- a/src/js/ui/startScreen.js
+++ b/src/js/ui/startScreen.js
@@ -140,9 +140,7 @@ function renderHeroGrid({
         dataset: { selected: heroId && heroId === selectedId ? '1' : '0' },
         aria: ariaAttrs,
       },
-      el('span', { class: 'start-screen__hero-card' }, tooltipCard),
-      el('span', { class: 'start-screen__hero-name' }, heroName),
-      hero?.text ? el('span', { class: 'start-screen__hero-text' }, hero.text) : null);
+      el('span', { class: 'start-screen__hero-card' }, tooltipCard));
       children.push(btn);
     }
   } else if (loading) {

--- a/styles.css
+++ b/styles.css
@@ -862,14 +862,14 @@ ul.zone-list li {
 .start-screen__hero {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 18px;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 18px 24px;
   border-radius: 14px;
   border: 1px solid rgba(84, 140, 220, 0.45);
   background: rgba(16, 28, 44, 0.85);
   color: inherit;
-  text-align: left;
+  text-align: center;
   cursor: pointer;
   transition: border-color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
 }
@@ -886,15 +886,37 @@ ul.zone-list li {
   box-shadow: 0 0 0 2px rgba(160, 216, 255, 0.35), 0 18px 32px rgba(0, 0, 0, 0.4);
 }
 
+.start-screen__hero-card {
+  width: 220px;
+  height: 330px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.start-screen__hero-card > .card-tooltip {
+  width: 220px;
+  pointer-events: none;
+  transition: transform 120ms ease;
+}
+
+.start-screen__hero:hover .start-screen__hero-card > .card-tooltip,
+.start-screen__hero:focus-visible .start-screen__hero-card > .card-tooltip,
+.start-screen__hero[data-selected='1'] .start-screen__hero-card > .card-tooltip {
+  transform: translateY(-2px);
+}
+
 .start-screen__hero-name {
   font-size: 18px;
   font-weight: 600;
   color: #e6f3ff;
+  display: block;
 }
 
 .start-screen__hero-text {
   font-size: 14px;
   color: #a8bed8;
+  max-width: 26ch;
 }
 
 .start-screen__empty {

--- a/styles.css
+++ b/styles.css
@@ -779,3 +779,138 @@ ul.zone-list li {
 .card-tooltip.attack-bump {
   animation: attack-bump 0.28s ease;
 }
+
+/* Start screen overlay */
+.start-screen {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 6vw, 48px);
+  background: linear-gradient(180deg, rgba(4, 10, 16, 0.92), rgba(6, 12, 20, 0.88));
+  backdrop-filter: blur(6px);
+  z-index: 400;
+}
+
+.start-screen__panel {
+  width: min(720px, 100%);
+  max-height: min(80vh, 640px);
+  overflow: auto;
+  padding: clamp(24px, 4vw, 36px);
+  background: rgba(15, 24, 36, 0.92);
+  border: 1px solid rgba(108, 176, 255, 0.35);
+  border-radius: 18px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+  text-align: center;
+}
+
+.start-screen__title {
+  margin: 0;
+  font-size: clamp(28px, 5vw, 38px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #e6f3ff;
+}
+
+.start-screen__subtitle {
+  margin: 0;
+  font-size: clamp(16px, 2.5vw, 20px);
+  color: #9fb7d3;
+}
+
+.start-screen__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+}
+
+.start-screen__button {
+  min-width: 160px;
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: 1px solid rgba(140, 196, 255, 0.6);
+  background: rgba(22, 38, 58, 0.9);
+  color: #e6f3ff;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.start-screen__button:hover,
+.start-screen__button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+.start-screen__button--primary {
+  background: linear-gradient(135deg, rgba(77, 140, 255, 0.95), rgba(34, 96, 198, 0.95));
+  border-color: rgba(128, 192, 255, 0.95);
+}
+
+.start-screen__hero-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.start-screen__hero {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(84, 140, 220, 0.45);
+  background: rgba(16, 28, 44, 0.85);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
+}
+
+.start-screen__hero:hover,
+.start-screen__hero:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(140, 196, 255, 0.9);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.start-screen__hero[data-selected='1'] {
+  border-color: rgba(160, 216, 255, 1);
+  box-shadow: 0 0 0 2px rgba(160, 216, 255, 0.35), 0 18px 32px rgba(0, 0, 0, 0.4);
+}
+
+.start-screen__hero-name {
+  font-size: 18px;
+  font-weight: 600;
+  color: #e6f3ff;
+}
+
+.start-screen__hero-text {
+  font-size: 14px;
+  color: #a8bed8;
+}
+
+.start-screen__empty {
+  margin: 0 auto;
+  font-size: 16px;
+  color: #a8bed8;
+}
+
+@media (max-width: 640px) {
+  .start-screen__panel {
+    max-height: none;
+    height: auto;
+  }
+
+  .start-screen__hero-grid {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/styles.css
+++ b/styles.css
@@ -860,35 +860,23 @@ ul.zone-list li {
 }
 
 .start-screen__hero {
-  display: flex;
-  flex-direction: column;
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  padding: 18px 18px 24px;
-  border-radius: 14px;
-  border: 1px solid rgba(84, 140, 220, 0.45);
-  background: rgba(16, 28, 44, 0.85);
+  justify-content: center;
+  width: 220px;
+  height: 330px;
+  justify-self: center;
+  padding: 0;
+  border: none;
+  background: none;
   color: inherit;
-  text-align: center;
   cursor: pointer;
-  transition: border-color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
-}
-
-.start-screen__hero:hover,
-.start-screen__hero:focus-visible {
-  transform: translateY(-2px);
-  border-color: rgba(140, 196, 255, 0.9);
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
-}
-
-.start-screen__hero[data-selected='1'] {
-  border-color: rgba(160, 216, 255, 1);
-  box-shadow: 0 0 0 2px rgba(160, 216, 255, 0.35), 0 18px 32px rgba(0, 0, 0, 0.4);
+  transition: transform 120ms ease;
 }
 
 .start-screen__hero-card {
-  width: 220px;
-  height: 330px;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -897,26 +885,18 @@ ul.zone-list li {
 .start-screen__hero-card > .card-tooltip {
   width: 220px;
   pointer-events: none;
-  transition: transform 120ms ease;
+  transition: transform 120ms ease, box-shadow 120ms ease;
 }
 
 .start-screen__hero:hover .start-screen__hero-card > .card-tooltip,
-.start-screen__hero:focus-visible .start-screen__hero-card > .card-tooltip,
+.start-screen__hero:focus-visible .start-screen__hero-card > .card-tooltip {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
 .start-screen__hero[data-selected='1'] .start-screen__hero-card > .card-tooltip {
   transform: translateY(-2px);
-}
-
-.start-screen__hero-name {
-  font-size: 18px;
-  font-weight: 600;
-  color: #e6f3ff;
-  display: block;
-}
-
-.start-screen__hero-text {
-  font-size: 14px;
-  color: #a8bed8;
-  max-width: 26ch;
+  box-shadow: 0 0 0 2px rgba(160, 216, 255, 0.35), 0 18px 32px rgba(0, 0, 0, 0.4);
 }
 
 .start-screen__empty {


### PR DESCRIPTION
## Summary
- add a multi-step start screen that lets players continue a save, choose their hero, and pick an opponent before a new match begins
- update the game reset logic to accept an explicit opponent deck/hero and wire the UI to use the selected decks
- add styling for the new overlay and cover the forced opponent deck path with a regression test

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d790fa68308323b2123f2f59da0e2f