### PR TITLE
feat: add start screen hero selection flow

### DIFF
--- a/__tests__/game.setupMatch.opponentDeck.test.js
+++ b/__tests__/game.setupMatch.opponentDeck.test.js
@@ -1,0 +1,37 @@
+import Game from '../src/js/game.js';
+import { fillDeckRandomly } from '../src/js/utils/deckbuilder.js';
+
+function buildDeckForHero(game, hero) {
+  const state = { hero, cards: [] };
+  fillDeckRandomly(state, game.allCards, game.rng);
+  return { hero: state.hero, cards: Array.isArray(state.cards) ? state.cards.slice() : [] };
+}
+
+describe('Game.setupMatch opponent deck override', () => {
+  test('uses provided opponent deck hero and cards', async () => {
+    const game = new Game(null);
+    await game.init();
+    const heroes = game.allCards.filter((card) => card?.type === 'hero');
+    expect(heroes.length).toBeGreaterThan(1);
+
+    const prebuiltDecks = await game.getPrebuiltDecks();
+    expect(prebuiltDecks.length).toBeGreaterThan(0);
+    const opponentTemplate = prebuiltDecks.find((deck) => deck?.hero && deck.cards?.length === 60);
+    expect(opponentTemplate).toBeTruthy();
+
+    const playerHero = heroes.find((hero) => hero.id !== opponentTemplate.hero.id) || heroes[0];
+    const playerDeck = buildDeckForHero(game, playerHero);
+    const opponentDeck = {
+      hero: opponentTemplate.hero,
+      cards: opponentTemplate.cards.slice(),
+    };
+    playerDeck.opponentDeck = opponentDeck;
+
+    await game.reset(playerDeck);
+
+    expect(game.opponent.hero?.id).toBe(opponentDeck.hero.id);
+    const opponentLibraryIds = game.opponent.library.cards.map((card) => card.id);
+    const expectedIds = opponentDeck.cards.map((card) => card.id);
+    expect(new Set(opponentLibraryIds)).toEqual(new Set(expectedIds));
+  });
+});

--- a/src/js/utils/savegame.js
+++ b/src/js/utils/savegame.js
@@ -452,6 +452,23 @@ export function saveGameState(game) {
   }
 }
 
+export function hasSavedGameState() {
+  try {
+    const save = getSave();
+    const raw = save.storage.getItem(save.key(GAME_STATE_KEY));
+    if (!raw) return false;
+    try {
+      JSON.parse(raw);
+    } catch {
+      save.storage.removeItem(save.key(GAME_STATE_KEY));
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function loadSavedGameState(game) {
   try {
     const save = getSave();

--- a/styles.css
+++ b/styles.css
@@ -592,6 +592,152 @@ ul.zone-list li {
   opacity: 0;
 }
 
+.start-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(2, 6, 23, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  backdrop-filter: blur(2px);
+}
+
+.start-screen[hidden] {
+  display: none;
+}
+
+.start-screen__panel {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 960px;
+  width: min(960px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.start-screen__title {
+  margin: 0;
+  font-size: 2rem;
+  color: #f8fafc;
+  text-align: center;
+}
+
+.start-screen__message {
+  margin: 0;
+  color: #cbd5f5;
+  text-align: center;
+}
+
+.start-screen__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.start-screen__button {
+  padding: 12px 24px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(30, 41, 59, 0.85);
+  color: #e2e8f0;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.start-screen__button:hover {
+  background: rgba(51, 65, 85, 0.95);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.4);
+}
+
+.start-screen__button:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+.start-screen__button--primary {
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #f8fafc;
+}
+
+.start-screen__button--primary:hover {
+  background: linear-gradient(135deg, #1d4ed8, #6d28d9);
+}
+
+.start-screen__back {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 4px 0;
+  transition: color 0.2s ease;
+}
+
+.start-screen__back:hover {
+  color: #cbd5f5;
+}
+
+.start-screen__back:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+.start-screen__heroes {
+  width: 100%;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  justify-items: center;
+}
+
+.start-screen__hero-card {
+  cursor: pointer;
+  max-width: 220px;
+  width: 100%;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.start-screen__hero-card:hover,
+.start-screen__hero-card:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.55);
+}
+
+.start-screen__hero-card:focus-visible {
+  outline: 3px solid #38bdf8;
+  outline-offset: 4px;
+}
+
+.start-screen__status {
+  color: #e2e8f0;
+  font-size: 1.1rem;
+  text-align: center;
+  margin: 24px 0;
+}
+
+@media (max-width: 640px) {
+  .start-screen__panel {
+    padding: 16px;
+  }
+
+  .start-screen__title {
+    font-size: 1.5rem;
+  }
+}
+
 @keyframes aiProgressSheen {
   0% { background-position: -150% 0; }
   100% { background-position: 150% 0; }


### PR DESCRIPTION
## Summary
- add a start overlay that lets players continue or pick heroes before starting a new game
- style the start flow UI and gate autosaving until a selection is made
- teach game setup to honor provided opponent decks and cover it with a regression test

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d790fa68308323b2123f2f59da0e2f