### PR TITLE
Fix player hand UI after AI opening draw

### DIFF
--- a/__tests__/game.starting-player.test.js
+++ b/__tests__/game.starting-player.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import Game from '../src/js/game.js';
 import { RNG } from '../src/js/utils/rng.js';
 
@@ -74,5 +75,22 @@ describe('starting player selection', () => {
     } finally {
       game.resources.startTurn = originalStartTurn;
     }
+  });
+
+  test('rerender triggers when player takes first turn after AI opener', async () => {
+    const game = new Game(null, { aiPlayers: ['opponent'] });
+    game.state.difficulty = 'easy';
+    const rerender = jest.fn();
+    game.setUIRerender(rerender);
+    game._takeTurnWithDifficultyAI = jest.fn().mockResolvedValue(undefined);
+    game.rng = new RNG(4);
+
+    await game.setupMatch();
+
+    expect(game.state.startingPlayer).toBe('opponent');
+    expect(game.turns.activePlayer).toBe(game.player);
+    expect(game.player.hand.cards.length).toBe(4);
+    expect(game._takeTurnWithDifficultyAI).toHaveBeenCalled();
+    expect(rerender).toHaveBeenCalled();
   });
 });

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -164,6 +164,9 @@ export default class Game {
           && player === this.opponent
           && (difficulty === 'medium' || difficulty === 'hard' || difficulty === 'nightmare' || difficulty === 'insane');
         if (player && !aiHandlesDraw) this.draw(player, 1);
+        if (player) {
+          try { this._uiRerender?.(); } catch {}
+        }
       });
 
       this.turns.bus.on('phase:end', ({ phase }) => {


### PR DESCRIPTION
## Summary
- ensure turn start draws trigger a UI rerender so the opening hand updates immediately
- add a regression test that stubs the AI turn to verify the rerender occurs after the AI opens

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d839fd61b8832398ea607dd9b3dbdd