### PR TITLE
feat: show deck count next to mana display

### DIFF
--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -56,17 +56,17 @@ describe('UI Play', () => {
     renderPlay(container, game);
 
     const enemyMana = container.querySelector('.ai-hero .hero-mana');
-    expect(enemyMana.textContent).toBe('7/4 Mana');
+    expect(enemyMana.textContent).toBe('7/4 Mana · Deck: 0');
     const playerMana = container.querySelector('.p-hero .hero-mana');
-    expect(playerMana.textContent).toBe('5/3 Mana');
+    expect(playerMana.textContent).toBe('5/3 Mana · Deck: 0');
 
     resources.pool.mockImplementation((owner) => (owner === player ? 6 : 8));
     resources.available.mockImplementation((owner) => (owner === player ? 4 : 5));
 
     renderPlay(container, game);
 
-    expect(container.querySelector('.ai-hero .hero-mana').textContent).toBe('8/5 Mana');
-    expect(container.querySelector('.p-hero .hero-mana').textContent).toBe('6/4 Mana');
+    expect(container.querySelector('.ai-hero .hero-mana').textContent).toBe('8/5 Mana · Deck: 0');
+    expect(container.querySelector('.p-hero .hero-mana').textContent).toBe('6/4 Mana · Deck: 0');
   });
 
   test('new game button appears before deck builder and triggers handler', async () => {

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -800,6 +800,13 @@ export function renderPlay(container, game, {
   const debugEnabled = !!(game.state?.debug);
   const defaultDifficulty = game?._defaultDifficulty || 'insane';
 
+  const formatManaAndDeck = (player) => {
+    const pool = game.resources.pool(player);
+    const available = game.resources.available(player);
+    const deckCount = player?.library?.cards?.length ?? 0;
+    return `${pool}/${available} Mana · Deck: ${deckCount}`;
+  };
+
   ensureAttackAnimationSubscription(game);
 
   let headerEl = document.querySelector('header');
@@ -909,7 +916,7 @@ export function renderPlay(container, game, {
       'div',
       { class: 'slot ai-hero' },
       buildCardEl(e.hero),
-      el('div', { class: 'hero-mana' }, `${game.resources.pool(e)}/${game.resources.available(e)} Mana`),
+      el('div', { class: 'hero-mana' }, formatManaAndDeck(e)),
       buildAiHandIndicator(e.hand)
     );
     attachCardInteractions(aiHero.querySelector('.card-tooltip'), e.hero);
@@ -922,7 +929,7 @@ export function renderPlay(container, game, {
       'div',
       { class: 'slot p-hero' },
       buildCardEl(p.hero),
-      el('div', { class: 'hero-mana' }, `${game.resources.pool(p)}/${game.resources.available(p)} Mana`)
+      el('div', { class: 'hero-mana' }, formatManaAndDeck(p))
     );
     attachCardInteractions(pHero.querySelector('.card-tooltip'), p.hero, async () => {
       await game.attack(game.player, game.player.hero);
@@ -990,9 +997,9 @@ export function renderPlay(container, game, {
 
   // Update mana displays
   const aiManaEl = board.querySelector('.ai-hero .hero-mana');
-  aiManaEl?.replaceChildren(`${game.resources.pool(e)}/${game.resources.available(e)} Mana`);
+  aiManaEl?.replaceChildren(formatManaAndDeck(e));
   const playerManaEl = board.querySelector('.p-hero .hero-mana');
-  playerManaEl?.replaceChildren(`${game.resources.pool(p)}/${game.resources.available(p)} Mana`);
+  playerManaEl?.replaceChildren(formatManaAndDeck(p));
 
   // Update hero cards
   const aiHeroCard = board.querySelector('.ai-hero .card-tooltip');


### PR DESCRIPTION
## Summary
- show the remaining deck size alongside each hero's mana indicator during play
- update the UI play test to reflect the new mana and deck text

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8473ae608832381e2cdcf3a18a426