### PR TITLE
Adjust target prompt layout for clarity

### DIFF
--- a/__tests__/effects.prompt-title.test.js
+++ b/__tests__/effects.prompt-title.test.js
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+import { EffectSystem } from '../src/js/systems/effects.js';
+
+function createHero(name) {
+  return {
+    name,
+    type: 'hero',
+    data: { health: 30 },
+  };
+}
+
+describe('target prompt titles', () => {
+  test('damage prompt includes amount', async () => {
+    const playerHero = createHero('Player Hero');
+    const enemyHero = createHero('Enemy Hero');
+
+    const player = {
+      hero: playerHero,
+      battlefield: { cards: [] },
+      graveyard: { add: () => {} },
+    };
+    const opponent = {
+      hero: enemyHero,
+      battlefield: { cards: [] },
+      graveyard: { add: () => {} },
+    };
+
+    const game = {
+      player,
+      opponent,
+      CANCEL: Symbol('CANCEL'),
+      promptTarget: jest.fn(async (candidates) => candidates[0] ?? null),
+      bus: { emit: jest.fn(), on: jest.fn() },
+      turns: { activePlayer: null, bus: { on: jest.fn(() => () => {}) } },
+      cleanupDeaths: jest.fn(),
+      checkForGameOver: jest.fn(),
+    };
+
+    player.opponent = opponent;
+    opponent.opponent = player;
+
+    const effects = new EffectSystem(game);
+    const effect = { type: 'damage', target: 'any', amount: 3 };
+    const context = { game, player, card: { name: 'Test Spell', type: 'spell' } };
+
+    await effects.dealDamage(effect, context);
+
+    expect(game.promptTarget).toHaveBeenCalled();
+    const options = game.promptTarget.mock.calls[0][1] || {};
+    expect(options.title).toBe('Deal 3 damage');
+  });
+});

--- a/__tests__/effects.sunder-armor.test.js
+++ b/__tests__/effects.sunder-armor.test.js
@@ -40,6 +40,8 @@ describe('Sunder Armor targeting', () => {
     const candidates = game.promptTarget.mock.calls[0][0];
     const names = candidates.map(c => c.name);
     expect(names).toContain('Enemy Hero');
+    const options = game.promptTarget.mock.calls[0][1] || {};
+    expect(options.title).toBe('Apply -2 Armor');
   });
 });
 

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -1476,7 +1476,10 @@ export default class Game {
     try { this._uiRerender?.(); } catch {}
   }
 
-  async promptTarget(candidates, { allowNoMore = false, preferredSide = 'enemy', actingPlayer = null } = {}) {
+  async promptTarget(
+    candidates,
+    { allowNoMore = false, preferredSide = 'enemy', actingPlayer = null, title = null } = {}
+  ) {
     candidates = candidates?.filter(c => c.type !== 'quest');
     const pendingBattlecryCard = this._pendingBattlecryCard;
     if (pendingBattlecryCard) {
@@ -1558,7 +1561,11 @@ export default class Game {
       let resolved = false;
       let showTimer = null;
 
+      const content = document.createElement('div');
+      content.className = 'target-prompt__content';
+
       const list = document.createElement('ul');
+      list.className = 'target-prompt__targets';
 
       const enemy = this.opponent;
 
@@ -1581,7 +1588,16 @@ export default class Game {
         list.appendChild(li);
       });
 
-      overlay.appendChild(list);
+      if (title) {
+        const heading = document.createElement('h2');
+        heading.textContent = title;
+        content.appendChild(heading);
+      }
+
+      content.appendChild(list);
+
+      const buttons = document.createElement('div');
+      buttons.className = 'target-prompt__buttons';
 
       if (allowNoMore) {
         const done = document.createElement('button');
@@ -1589,7 +1605,7 @@ export default class Game {
         done.addEventListener('click', () => {
           finish(null);
         });
-        overlay.appendChild(done);
+        buttons.appendChild(done);
       }
 
       // Always provide a cancel option to close without choosing
@@ -1598,7 +1614,10 @@ export default class Game {
       cancel.addEventListener('click', () => {
         finish(this.CANCEL);
       });
-      overlay.appendChild(cancel);
+      buttons.appendChild(cancel);
+
+      content.appendChild(buttons);
+      overlay.appendChild(content);
 
       const showOverlay = () => {
         if (resolved || overlay.parentNode) return;

--- a/styles.css
+++ b/styles.css
@@ -568,22 +568,39 @@ ul.zone-list li {
   z-index: 1000; /* ensure above card tooltips */
 }
 
-.target-prompt ul {
+.target-prompt__content {
   background: var(--color-bg-panel);
-  list-style: none;
   padding: 1em;
   border: 1px solid var(--color-border-soft);
   box-shadow: 0 18px 32px var(--color-shadow-strong);
+  min-width: 280px;
 }
 
-.target-prompt li {
+.target-prompt__content h2 {
+  margin: 0 0 0.75em;
+  font-size: 1.15em;
+}
+
+.target-prompt__targets {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.target-prompt__targets li {
   cursor: pointer;
   margin: 0.25em 0;
   padding: 4px 6px;
 }
 
-.target-prompt button {
-  margin-top: 0.5em;
+.target-prompt__buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  margin-top: 1em;
+}
+
+.target-prompt__buttons button {
   padding: 4px 6px;
   border-radius: 999px;
   border: 1px solid var(--color-border-soft);


### PR DESCRIPTION
## Summary
- wrap the target prompt UI in a structured container so effect titles render above targets and actions sit below
- update target prompt styles to support the new layout while preserving existing visual treatments

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8479abb508323b1c612e3cc5c6d79