### PR TITLE
feat: animate cards when played

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -962,6 +962,17 @@ ul.zone-list li {
   pointer-events: none;
 }
 
+.card-play-float {
+  pointer-events: none;
+  z-index: 902;
+  filter: drop-shadow(0 10px 24px rgba(0, 0, 0, 0.45));
+}
+
+.card-play-float img,
+.card-play-float .card-info {
+  pointer-events: none;
+}
+
 @keyframes attack-bump {
   0% { transform: translate3d(0, 0, 0) scale(1); }
   45% { transform: translate3d(3px, -4px, 0) scale(1.05); }


### PR DESCRIPTION
## Summary
- add a card play animation that floats the played card above the acting hero before fading away
- reuse the attack animation layer for played card overlays and add styling for the floating card clone

## Testing
- npm test *(fails: structuredClone fallback could not clone value in __tests__/combat-log.targets.test.js)*
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8dfabf7888323a9cd863da68e635a