### PR TITLE
Add hero overlay animation for played cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -962,6 +962,21 @@ ul.zone-list li {
   pointer-events: none;
 }
 
+.card-play-anim {
+  position: fixed;
+  pointer-events: none;
+  z-index: 902;
+  filter: drop-shadow(0 0 20px rgba(255, 240, 200, 0.6));
+  transform-origin: top left;
+  will-change: transform, opacity, filter;
+  opacity: 0;
+}
+
+.card-play-anim img,
+.card-play-anim .card-info {
+  pointer-events: none;
+}
+
 @keyframes attack-bump {
   0% { transform: translate3d(0, 0, 0) scale(1); }
   45% { transform: translate3d(3px, -4px, 0) scale(1.05); }


### PR DESCRIPTION
## Summary
- subscribe the play view to cardPlayed events and animate card clones above the acting hero
- render the card play animation in the existing attack animation layer and align it with the hero position
- add styling for the card play overlay so it fades upward while remaining non-interactive

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8dfabf7888323a9cd863da68e635a