### PR TITLE
fix: allow double tap hero attack on mobile

### DIFF
--- a/__tests__/ui.play.test.js
+++ b/__tests__/ui.play.test.js
@@ -642,11 +642,13 @@ describe('UI Play', () => {
     playerHeroEl.dispatchEvent(new PointerEvent('pointerup', { pointerType: 'touch', bubbles: true, cancelable: true }));
     await Promise.resolve();
     expect(playerHeroEl.dataset.touchPreview).toBeUndefined();
-    expect(attack).not.toHaveBeenCalled();
+    expect(attack).toHaveBeenCalledTimes(1);
+    expect(attack).toHaveBeenCalledWith(game.player, game.player.hero);
 
     playerHeroEl.dispatchEvent(new PointerEvent('pointerup', { pointerType: 'mouse', bubbles: true, cancelable: true }));
     await Promise.resolve();
-    expect(attack).toHaveBeenCalledWith(game.player, game.player.hero);
+    expect(attack).toHaveBeenCalledTimes(2);
+    expect(attack).toHaveBeenLastCalledWith(game.player, game.player.hero);
 
     nowSpy.mockRestore();
   });

--- a/src/js/ui/play.js
+++ b/src/js/ui/play.js
@@ -204,13 +204,14 @@ function attachCardInteractions(node, card, clickCard) {
       const now = getNow();
       const isPreviewed = touchPreviewCardEl === node;
       const isFriendlyFieldAlly = state.card?.type === 'ally' && !!node.closest('.p-field');
+      const isFriendlyHero = state.card?.type === 'hero' && !!node.closest('.slot.p-hero');
       const isPlayerHandCard = !!node.closest('.p-hand');
       const canActivate = typeof state.clickCard === 'function';
       state.lastTap = now;
       if (isPreviewed) {
         clearTouchPreview(node);
         state.lastTap = 0;
-        if (canActivate && (isFriendlyFieldAlly || isPlayerHandCard)) await state.clickCard(state.card);
+        if (canActivate && (isFriendlyFieldAlly || isFriendlyHero || isPlayerHandCard)) await state.clickCard(state.card);
         return;
       }
       setTouchPreview(node);


### PR DESCRIPTION
## Summary
- trigger the player hero attack when a touch preview is tapped again on mobile
- update the touch interaction test to cover the new double-tap hero behavior

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d928639bbc8323bddb3336e3d89201